### PR TITLE
Prepare v0.2.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-01
+
 ### Added
 
 - Write-ahead journal persistence (`memories.json.wal.jsonl`) for mutating operations with startup replay and compaction into `memories.json`

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ If you want to use the mcp server in Github Copilot Agent Workflows (github spin
       "type": "stdio",
       "command": "npx",
       "args": [
-        "neurodivergent-memory@0.1.8"
+        "neurodivergent-memory@0.2.0"
       ],
       "env": {
         "NEURODIVERGENT_MEMORY_DIR": ".neurodivergent-memory"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neurodivergent-memory",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neurodivergent-memory",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "mcpName": "io.github.jmeyer1980/neurodivergent-memory",
   "description": "A Model Context Protocol server for knowledge graphs designed around neurodivergent thinking patterns",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- set package version to `0.2.0` in package metadata files
- add explicit `0.2.0` release section in CHANGELOG
- update README package pin example to `neurodivergent-memory@0.2.0`

## Why
Tag validation failed because `v0.2.0` did not match package version on main.
This PR aligns release metadata so tag checks pass.

## Validation
- `npm run lint`
- `npm test` (24/24 passing)
