### PR TITLE
feat: add distill_memory tool for emotional-to-logical translation (#54)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1613,6 +1613,10 @@ class NeurodivergentMemory {
     };
   }
 
+  /**
+   * Import multiple memories in a single WAL-backed operation.
+   * Materializes entries first so the import record is appended before in-memory mutation.
+   */
   importMemories(entries: Array<{ content: string; district: string; tags?: string[]; emotional_valence?: number; intensity?: number; agent_id?: string; project_id?: string; epistemic_status?: EpistemicStatus }>, default_agent_id?: string): string[] {
     const materialized = this.materializeImportMemories(entries, default_agent_id);
     // Append WAL entry for the import before mutating in-memory state to preserve the

--- a/test/distill-memory.test.mjs
+++ b/test/distill-memory.test.mjs
@@ -38,7 +38,11 @@ function callTool(name, args) {
 async function setup() {
   const persistDir = mkdtempSync(join(realpathSync(tmpdir()), 'ndm-distill-'));
   child = spawn('node', [MCP_SERVER], {
-    env: { ...process.env, HOME: persistDir },
+    env: {
+      ...process.env,
+      HOME: persistDir,
+      NEURODIVERGENT_MEMORY_DIR: persistDir,
+    },
     stdio: ['pipe', 'pipe', 'inherit'],
   });
 


### PR DESCRIPTION
## Summary

Implements Issue #54: adds a first-class \distill_memory\ tool that translates \motional_processing\ memories into structured logical artifacts. This prevents analysis-rumination loops by ensuring logical/planning agents consume structured input rather than raw emotional narrative.

## Changes

- **\distillMemory\ method** in \NeurodivergentMemory\ class: pattern-based extraction of signals, triggers, constraints, next_actions, and risk_flags from emotional content
- **Distilled memory creation**: new memory in \logical_analysis\ district with reduced intensity (40% of source) and neutral emotional valence (0)
- **\bstracted_from\ pointer**: links distilled memory back to source emotional memory without exposing full emotional content
- **Bidirectional connection**: source and distilled memories are connected for traceability
- **WAL persistence**: distilled memories are persisted with the same reliability guarantees
- **Tool schema + handler**: registered as \distill_memory\ MCP tool with \memory_id\ and optional \gent_id\ parameters

## Acceptance Criteria

- [x] \distill_memory\ tool added — accepts an \motional_processing\ memory ID as input
- [x] Output shape: \signals\, \	riggers\, \constraints\, \
ext_actions\, \isk_flags\
- [x] \bstracted_from\ pointer added on distilled memories — links back to source emotional memory
- [x] Implements **selective abstraction**: emotional signal is preserved, intensity is reduced, logical layer receives structured input
- [x] Only operates on \motional_processing\ memories — returns clear error for other districts

## Validation

- TypeScript build: \u2705
- Smoke test: \u2705

## Related

- Milestone: v0.3.0 — Distillation & Contextual Intelligence
- Companion issue: #55 (Loop Behavior Guardrails)