### PR TITLE
feat: add import diagnostics and storage visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Import validation flags:
 - `dry_run: true` validates the request without writing data and returns deterministic `would_import`, `would_skip`, and `would_fail` counts.
 - `dedupe` accepts `none`, `content_hash`, or `content_plus_tags`.
 - Deduplicated rows are reported with stable reason codes: `DEDUPE_CONTENT_HASH` or `DEDUPE_CONTENT_PLUS_TAGS`.
+- Snapshot `file_path` imports accept `.json` files under the resolved persistence directory by default. Set `NEURODIVERGENT_MEMORY_IMPORT_ALLOW_EXTERNAL_FILE=true` only when importing external snapshot files intentionally.
 
 Snapshot migration flags:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import * as crypto from "crypto";
 import * as fs from "fs";
+import * as path from "path";
 import { logger } from "./core/logger.js";
 import { resolvePersistenceLocation } from "./core/persistence.js";
 import { AsyncMutex } from "./core/async-mutex.js";
@@ -346,6 +347,10 @@ class NeurodivergentMemory {
     process.env.NEURODIVERGENT_MEMORY_PING_PONG_THRESHOLD,
     3,
     (value) => value > 0,
+  );
+  private readonly allowExternalImportFiles = parseBooleanEnv(
+    process.env.NEURODIVERGENT_MEMORY_IMPORT_ALLOW_EXTERNAL_FILE,
+    false,
   );
   private readonly loopTelemetry = new LoopTelemetryTracker({
     operationWindowSize: this.loopTelemetryWindowSize,
@@ -808,10 +813,38 @@ class NeurodivergentMemory {
     };
   }
 
+  private validateImportFilePath(filePath: string): string {
+    const resolvedPath = path.resolve(filePath);
+    const resolvedPersistenceDir = path.resolve(PERSISTENCE_DIR);
+    const hasJsonExtension = path.extname(resolvedPath).toLowerCase() === ".json";
+    if (!hasJsonExtension) {
+      throw createNMError(
+        NM_ERRORS.INPUT_VALIDATION_FAILED,
+        `Import file must use a .json extension: ${filePath}`,
+        "Provide a JSON snapshot file path ending in .json.",
+      );
+    }
+
+    const isWithinPersistenceDir =
+      resolvedPath === resolvedPersistenceDir ||
+      resolvedPath.startsWith(`${resolvedPersistenceDir}${path.sep}`);
+
+    if (!this.allowExternalImportFiles && !isWithinPersistenceDir) {
+      throw createNMError(
+        NM_ERRORS.INPUT_VALIDATION_FAILED,
+        `Import file path is outside the allowed persistence directory: ${filePath}`,
+        `Place the snapshot under ${resolvedPersistenceDir}, or set NEURODIVERGENT_MEMORY_IMPORT_ALLOW_EXTERNAL_FILE=true if external file imports are intentional.`,
+      );
+    }
+
+    return resolvedPath;
+  }
+
   private readImportSnapshotFile(filePath: string): ImportCandidate[] {
+    const validatedPath = this.validateImportFilePath(filePath);
     let raw = "";
     try {
-      raw = fs.readFileSync(filePath, "utf-8");
+      raw = fs.readFileSync(validatedPath, "utf-8");
     } catch (error) {
       throw createNMError(
         NM_ERRORS.INPUT_VALIDATION_FAILED,
@@ -851,6 +884,13 @@ class NeurodivergentMemory {
 
     return ordered.map(([sourceMemoryId, rawMemory]) => {
       const deserialized = this.deserializeMemory(rawMemory);
+      if (deserialized.id !== sourceMemoryId) {
+        throw createNMError(
+          NM_ERRORS.INPUT_VALIDATION_FAILED,
+          `Snapshot memory id mismatch for ${sourceMemoryId}: embedded id is ${deserialized.id}.`,
+          "Ensure each snapshot memories key matches the embedded memory.id before retrying import_memories.",
+        );
+      }
       return {
         content: deserialized.content,
         district: deserialized.district,
@@ -874,27 +914,49 @@ class NeurodivergentMemory {
   }
 
   private fingerprintForImportCandidate(candidate: Pick<ImportCandidate, "content" | "tags">, dedupe: ImportDedupePolicy): string | undefined {
-    if (dedupe === "none") {
-      return undefined;
+    switch (dedupe) {
+      case "none":
+        return undefined;
+      case "content_hash":
+        return crypto.createHash("sha256").update(candidate.content).digest("hex");
+      case "content_plus_tags": {
+        const stableTags = [...(candidate.tags ?? [])].sort().join("\u0000");
+        return crypto.createHash("sha256").update(`${candidate.content}\u0001${stableTags}`).digest("hex");
+      }
     }
-
-    if (dedupe === "content_hash") {
-      return crypto.createHash("sha256").update(candidate.content).digest("hex");
-    }
-
-    const stableTags = [...(candidate.tags ?? [])].sort().join("\u0000");
-    return crypto.createHash("sha256").update(`${candidate.content}\u0001${stableTags}`).digest("hex");
   }
 
   private dedupeReasonCode(dedupe: ImportDedupePolicy): string {
     switch (dedupe) {
+      case "none":
+        return "NONE";
       case "content_hash":
         return "DEDUPE_CONTENT_HASH";
       case "content_plus_tags":
         return "DEDUPE_CONTENT_PLUS_TAGS";
-      default:
-        return "NONE";
     }
+  }
+
+  private validateImportDedupePolicy(dedupe: string | undefined): ImportDedupePolicy {
+    if (dedupe === undefined || dedupe === "none" || dedupe === "content_hash" || dedupe === "content_plus_tags") {
+      return dedupe ?? "none";
+    }
+
+    throw createNMError(
+      NM_ERRORS.INPUT_VALIDATION_FAILED,
+      `Invalid dedupe policy: ${dedupe}`,
+      "Use one of: none, content_hash, or content_plus_tags.",
+    );
+  }
+
+  private projectIdFieldPathForImport(planSource: "entries" | "file_path", index: number, candidate: ImportCandidate): string {
+    if (planSource === "file_path") {
+      return candidate.source_memory_id
+        ? `snapshot[${candidate.source_memory_id}].project_id`
+        : `snapshot[${index}].project_id`;
+    }
+
+    return `entries[${index}].project_id`;
   }
 
   private buildImportPlan(
@@ -902,7 +964,7 @@ class NeurodivergentMemory {
     default_agent_id: string | undefined,
     options: ImportExecutionOptions = {},
   ): ImportPlan {
-    const dedupe = options.dedupe ?? "none";
+    const dedupe = this.validateImportDedupePolicy(options.dedupe);
     const preserveIds = options.preserve_ids ?? false;
     const mergeConnections = options.merge_connections ?? false;
     const resolved = this.resolveImportCandidates(entries, options.file_path);
@@ -958,7 +1020,18 @@ class NeurodivergentMemory {
         }
 
         if (candidate.project_id !== undefined) {
-          validateProjectId(candidate.project_id, `entries[${index}].project_id`);
+          validateProjectId(candidate.project_id, this.projectIdFieldPathForImport(plan.source, index, candidate));
+        }
+
+        const fingerprint = this.fingerprintForImportCandidate(candidate, dedupe);
+        if (fingerprint && seenFingerprints.has(fingerprint)) {
+          plan.skipped.push({
+            index,
+            source_memory_id: candidate.source_memory_id,
+            reason_code: this.dedupeReasonCode(dedupe),
+            detail: `Skipped by dedupe policy ${dedupe}.`,
+          });
+          continue;
         }
 
         let targetId: string;
@@ -985,17 +1058,6 @@ class NeurodivergentMemory {
           targetId = sourceMemoryId;
         } else {
           targetId = `memory_${nextId++}`;
-        }
-
-        const fingerprint = this.fingerprintForImportCandidate(candidate, dedupe);
-        if (fingerprint && seenFingerprints.has(fingerprint)) {
-          plan.skipped.push({
-            index,
-            source_memory_id: candidate.source_memory_id,
-            reason_code: this.dedupeReasonCode(dedupe),
-            detail: `Skipped by dedupe policy ${dedupe}.`,
-          });
-          continue;
         }
 
         const districtArchetype = this.districts[candidate.district].archetype;
@@ -2467,6 +2529,22 @@ function parseIntegerEnv(
   }
 
   return parsed;
+}
+
+function parseBooleanEnv(rawValue: string | undefined, fallback: boolean): boolean {
+  if (!rawValue || !rawValue.trim()) {
+    return fallback;
+  }
+
+  const normalized = rawValue.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+
+  return fallback;
 }
 
 function parseNumberEnv(

--- a/test/import-diagnostics.test.mjs
+++ b/test/import-diagnostics.test.mjs
@@ -354,3 +354,197 @@ test("snapshot import rejects preserve_ids conflicts with clear error", async ()
     server.stop();
   }
 });
+
+test("dedupe skips do not consume memory ids on real import", async () => {
+  const server = startServer();
+
+  try {
+    await server.callTool(60, "store_memory", {
+      content: "existing duplicate seed",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:reference", "layer:research"],
+    });
+
+    const imported = await server.callTool(61, "import_memories", {
+      entries: [
+        {
+          content: "existing duplicate seed",
+          district: "logical_analysis",
+          tags: ["topic:test", "scope:session", "kind:reference", "layer:research"],
+        },
+        {
+          content: "only imported row",
+          district: "practical_execution",
+          tags: ["topic:test", "scope:session", "kind:task", "layer:implementation"],
+        },
+      ],
+      dedupe: "content_hash",
+    });
+    assert.equal(isToolError(imported), false, resultText(imported));
+    assert.match(resultText(imported), /Imported 1 memories/);
+    assert.match(resultText(imported), /memory_2/);
+
+    const stored = await server.callTool(62, "store_memory", {
+      content: "next id after skipped dedupe",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:reference", "layer:research"],
+    });
+    assert.match(resultText(stored), /ID: memory_3/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("invalid dedupe policy is rejected with validation error", async () => {
+  const server = startServer();
+
+  try {
+    const response = await server.callTool(70, "import_memories", {
+      entries: [
+        {
+          content: "bad dedupe policy",
+          district: "logical_analysis",
+        },
+      ],
+      dedupe: "bogus_policy",
+    });
+
+    assert.equal(isToolError(response), true, resultText(response));
+    assert.match(resultText(response), /Invalid dedupe policy/);
+    assert.match(resultText(response), /Code: NM_E020/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("snapshot import rejects key and embedded id mismatches", async () => {
+  const server = startServer();
+
+  try {
+    const snapshotPath = writeSnapshotFile(server.tempDir, "mismatch-snapshot.json", {
+      nextMemoryId: 2,
+      memories: {
+        memory_1: {
+          id: "memory_999",
+          name: "Mismatched Snapshot",
+          archetype: "scholar",
+          district: "logical_analysis",
+          content: "mismatch",
+          traits: ["analytical"],
+          concerns: ["accuracy"],
+          connections: [],
+          tags: ["topic:test", "scope:project", "kind:reference", "layer:architecture"],
+          created: "2026-04-01T00:00:00.000Z",
+          last_accessed: "2026-04-01T00:00:00.000Z",
+          access_count: 1,
+          intensity: 0.5,
+        },
+      },
+    });
+
+    const response = await server.callTool(71, "import_memories", {
+      file_path: snapshotPath,
+      dry_run: true,
+    });
+
+    assert.equal(isToolError(response), true, resultText(response));
+    assert.match(resultText(response), /Snapshot memory id mismatch/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("snapshot import validates project_id field paths with snapshot context", async () => {
+  const server = startServer();
+
+  try {
+    const snapshotPath = writeSnapshotFile(server.tempDir, "invalid-project-snapshot.json", {
+      nextMemoryId: 2,
+      memories: {
+        memory_1: {
+          id: "memory_1",
+          name: "Bad Project Snapshot",
+          archetype: "scholar",
+          district: "logical_analysis",
+          content: "invalid project id",
+          traits: ["analytical"],
+          concerns: ["accuracy"],
+          connections: [],
+          tags: ["topic:test", "scope:project", "kind:reference", "layer:architecture"],
+          created: "2026-04-01T00:00:00.000Z",
+          last_accessed: "2026-04-01T00:00:00.000Z",
+          access_count: 1,
+          intensity: 0.5,
+          project_id: "bad!",
+        },
+      },
+    });
+
+    const response = await server.callTool(72, "import_memories", {
+      file_path: snapshotPath,
+      dry_run: true,
+    });
+
+    assert.equal(isToolError(response), false, resultText(response));
+    assert.match(resultText(response), /snapshot\[memory_1\]\.project_id/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("snapshot import rejects external file paths unless explicitly enabled", async () => {
+  const externalDir = fs.mkdtempSync(path.join(os.tmpdir(), "ndm-external-import-"));
+  const externalSnapshotPath = writeSnapshotFile(externalDir, "external-snapshot.json", {
+    nextMemoryId: 2,
+    memories: {
+      memory_1: {
+        id: "memory_1",
+        name: "External Snapshot",
+        archetype: "scholar",
+        district: "logical_analysis",
+        content: "external file path import",
+        traits: ["analytical"],
+        concerns: ["accuracy"],
+        connections: [],
+        tags: ["topic:test", "scope:project", "kind:reference", "layer:architecture"],
+        created: "2026-04-01T00:00:00.000Z",
+        last_accessed: "2026-04-01T00:00:00.000Z",
+        access_count: 1,
+        intensity: 0.5,
+      },
+    },
+  });
+
+  const server = startServer();
+
+  try {
+    const blocked = await server.callTool(73, "import_memories", {
+      file_path: externalSnapshotPath,
+      dry_run: true,
+    });
+
+    assert.equal(isToolError(blocked), true, resultText(blocked));
+    assert.match(resultText(blocked), /outside the allowed persistence directory/);
+  } finally {
+    server.stop();
+  }
+
+  const allowedServer = startServer({
+    env: {
+      NEURODIVERGENT_MEMORY_IMPORT_ALLOW_EXTERNAL_FILE: "true",
+    },
+  });
+
+  try {
+    const allowed = await allowedServer.callTool(74, "import_memories", {
+      file_path: externalSnapshotPath,
+      dry_run: true,
+    });
+
+    assert.equal(isToolError(allowed), false, resultText(allowed));
+    assert.match(resultText(allowed), /Would import: 1/);
+  } finally {
+    allowedServer.stop();
+    fs.rmSync(externalDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a new storage_diagnostics MCP tool for resolved snapshot/WAL visibility
- extend import_memories with file_path, dry_run, dedupe policies, and snapshot migration validation
- add regression coverage for dedupe, dry-run, snapshot migration, invalid connections, and ID conflicts

## Testing
- npm run build
- node --test test/import-diagnostics.test.mjs
- npm test

Closes #59