### PR TITLE
feat: add LUCA-addressed custom districts (#58)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "neurodivergent-memory": "build/index.js"
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.5.1",
         "typescript": "^6.0.2"
       }
     },
@@ -79,9 +79,9 @@
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.1.tgz",
+      "integrity": "sha512-lgrR3HRNQdTEeeXBnLURFO4JIIbpcVcMlLM9IG0jsNRTRNSbMkm9S2hyhxhnokke1NM25Dr9QghgeB5PQKolrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pino": "^9.12.0"
   },
   "devDependencies": {
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.5.1",
     "typescript": "^6.0.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,7 +242,7 @@ interface MemorySnapshot {
   customDistricts?: { [key: string]: Omit<MemoryDistrict, "memories"> };
 }
 
-type WalOperation = "store" | "update" | "delete" | "connect" | "import";
+type WalOperation = "store" | "update" | "delete" | "connect" | "import" | "register_district";
 
 const PROJECT_ID_MAX_LENGTH = 64;
 const PROJECT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
@@ -596,6 +596,32 @@ class NeurodivergentMemory {
           }
         }
         return mutated;
+      }
+      case "register_district": {
+        const key = String(entry.payload.key ?? "");
+        // Skip if already registered (idempotent replay)
+        if (this.districts[key]) return false;
+        if ((CANONICAL_DISTRICTS as readonly string[]).includes(key)) return false;
+        const lucaParent = String(entry.payload.luca_parent ?? "");
+        if (!this.districts[lucaParent]) return false;
+        try {
+          const ancestor = this.resolveLucaAncestor(lucaParent);
+          const inheritedArchetype = this.districts[ancestor].archetype;
+          const activities = Array.isArray(entry.payload.activities)
+            ? (entry.payload.activities as string[])
+            : this.districts[lucaParent].activities.slice();
+          this.districts[key] = {
+            name: String(entry.payload.name ?? key),
+            description: String(entry.payload.description ?? ""),
+            archetype: inheritedArchetype,
+            activities,
+            memories: [],
+            luca_parent: lucaParent,
+          };
+          return true;
+        } catch {
+          return false;
+        }
       }
       default:
         return false;
@@ -1427,28 +1453,42 @@ class NeurodivergentMemory {
    * Returns the canonical district key if the chain is valid, or throws if it is broken.
    */
   private resolveLucaAncestor(districtKey: string): string {
-    const district = this.districts[districtKey];
-    if (!district) {
-      throw createNMError(
-        NM_ERRORS.UNKNOWN_DISTRICT,
-        `Unknown district in LUCA chain: ${districtKey}`,
-        "Ensure every district in the ancestry chain is registered before the child district.",
-      );
-    }
+    const visited = new Set<string>();
+    let currentDistrictKey = districtKey;
 
-    if ((CANONICAL_DISTRICTS as readonly string[]).includes(districtKey)) {
-      return districtKey;
-    }
+    while (true) {
+      if (visited.has(currentDistrictKey)) {
+        throw createNMError(
+          NM_ERRORS.INPUT_VALIDATION_FAILED,
+          `Cycle detected in LUCA chain while resolving district "${districtKey}": "${currentDistrictKey}" was visited more than once.`,
+          "Ensure every custom district's luca_parent chain is acyclic and ultimately traces back to one of the 5 canonical districts.",
+        );
+      }
+      visited.add(currentDistrictKey);
 
-    if (!district.luca_parent) {
-      throw createNMError(
-        NM_ERRORS.INPUT_VALIDATION_FAILED,
-        `Custom district "${districtKey}" has no luca_parent and is not a canonical district.`,
-        "Every custom district must declare a luca_parent that traces back to one of the 5 canonical districts.",
-      );
-    }
+      const district = this.districts[currentDistrictKey];
+      if (!district) {
+        throw createNMError(
+          NM_ERRORS.UNKNOWN_DISTRICT,
+          `Unknown district in LUCA chain: ${currentDistrictKey}`,
+          "Ensure every district in the ancestry chain is registered before the child district.",
+        );
+      }
 
-    return this.resolveLucaAncestor(district.luca_parent);
+      if ((CANONICAL_DISTRICTS as readonly string[]).includes(currentDistrictKey)) {
+        return currentDistrictKey;
+      }
+
+      if (!district.luca_parent) {
+        throw createNMError(
+          NM_ERRORS.INPUT_VALIDATION_FAILED,
+          `Custom district "${currentDistrictKey}" has no luca_parent and is not a canonical district.`,
+          "Every custom district must declare a luca_parent that traces back to one of the 5 canonical districts.",
+        );
+      }
+
+      currentDistrictKey = district.luca_parent;
+    }
   }
 
   /**
@@ -1511,6 +1551,13 @@ class NeurodivergentMemory {
       luca_parent: lucaParent,
     };
 
+    this.appendWalEntry("register_district", {
+      key,
+      name: district.name,
+      description: district.description,
+      luca_parent: lucaParent,
+      activities: district.activities,
+    });
     this.districts[key] = district;
     this.scheduleSave();
 
@@ -1520,6 +1567,24 @@ class NeurodivergentMemory {
     );
 
     return district;
+  }
+
+  /**
+   * Return the ancestry chain for a district key as an ordered array,
+   * starting from the given key and walking up via luca_parent until
+   * reaching a canonical district (which has no luca_parent).
+   *
+   * The caller is responsible for ensuring startKey is a registered district;
+   * if it is not, the returned array will contain only the unknown key.
+   */
+  getDistrictAncestryChain(startKey: string): string[] {
+    const chain: string[] = [];
+    let current: string | undefined = startKey;
+    while (current) {
+      chain.push(current);
+      current = this.districts[current]?.luca_parent;
+    }
+    return chain;
   }
 
   // ── Core CRUD ──────────────────────────────────────────────────────────────
@@ -4255,13 +4320,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           luca_parent,
           activities ?? [],
         );
-        const ancestorChain: string[] = [];
-        let current: string | undefined = luca_parent;
-        while (current) {
-          ancestorChain.push(current);
-          const parentDistrict = (memorySystem as any).districts?.[current];
-          current = parentDistrict?.luca_parent;
-        }
+        const ancestorChain = memorySystem.getDistrictAncestryChain(luca_parent);
 
         return {
           content: [{

--- a/test/luca-custom-districts.test.mjs
+++ b/test/luca-custom-districts.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 
 function startServer(options = {}) {
+  const ownsDir = !options.tempDir;
   const tempDir = options.tempDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "ndm-luca-test-"));
 
   fs.mkdirSync(tempDir, { recursive: true });
@@ -84,7 +85,9 @@ function startServer(options = {}) {
 
   function stop() {
     child.kill();
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    if (ownsDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   }
 
   return { callTool, stop, tempDir };
@@ -298,35 +301,33 @@ test("custom districts persist across snapshot load", async () => {
 
   // Verify snapshot file exists and contains custom district
   const snapshotPath = path.join(tempDir, "memories.json");
-  if (fs.existsSync(snapshotPath)) {
-    const snapshotRaw = fs.readFileSync(snapshotPath, "utf-8");
-    const snapshot = JSON.parse(snapshotRaw);
-    assert.ok(snapshot.customDistricts, "Snapshot should contain customDistricts");
-    assert.ok(snapshot.customDistricts.research_notes, "Snapshot should contain research_notes district");
-    assert.equal(snapshot.customDistricts.research_notes.luca_parent, "logical_analysis", "Custom district should have luca_parent");
+  assert.ok(fs.existsSync(snapshotPath), `Snapshot file should exist at ${snapshotPath}`);
+  const snapshotRaw = fs.readFileSync(snapshotPath, "utf-8");
+  const snapshot = JSON.parse(snapshotRaw);
+  assert.ok(snapshot.customDistricts, "Snapshot should contain customDistricts");
+  assert.ok(snapshot.customDistricts.research_notes, "Snapshot should contain research_notes district");
+  assert.equal(snapshot.customDistricts.research_notes.luca_parent, "logical_analysis", "Custom district should have luca_parent");
 
-    // Second session: verify custom district and memory survived restart
-    const server2 = startServer({ tempDir });
+  // Second session: verify custom district and memory survived restart
+  const server2 = startServer({ tempDir });
 
-    try {
-      // List memories to verify the custom district memory loaded
-      const listResponse = await server2.callTool(4, "list_memories", {
-        district: "research_notes",
-      });
+  try {
+    // List memories to verify the custom district memory loaded
+    const listResponse = await server2.callTool(4, "list_memories", {
+      district: "research_notes",
+    });
 
-      const text = resultText(listResponse);
-      assert.ok(text.includes("research_notes"), "Should list memories in custom district");
-      assert.ok(text.includes("Research methodology"), "Should show the stored memory");
+    const text = resultText(listResponse);
+    assert.ok(text.includes("research_notes"), "Should list memories in custom district");
+    assert.ok(text.includes("Research methodology"), "Should show the stored memory");
 
-      // Verify memory stats includes custom district
-      const statsResponse = await server2.callTool(5, "memory_stats", {});
-      const statsText = resultText(statsResponse);
-      assert.ok(statsText.includes("research_notes"), "Stats should include custom district");
-    } finally {
-      server2.stop();
-    }
+    // Verify memory stats includes custom district
+    const statsResponse = await server2.callTool(5, "memory_stats", {});
+    const statsText = resultText(statsResponse);
+    assert.ok(statsText.includes("research_notes"), "Stats should include custom district");
+  } finally {
+    server2.stop();
   }
-  // If snapshot doesn't exist, the test already verified in-session behavior above
 
   fs.rmSync(tempDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary

Implement custom district registration with fractal ancestry validation, allowing users to extend beyond the 5 canonical districts while maintaining a valid LUCA (Last Universal Common Ancestor) chain back to a canonical district.

## Changes

### Core Implementation (`src/index.ts`)

- Added `CANONICAL_DISTRICTS` constant listing the 5 canonical district keys
- Added `luca_parent` field to `MemoryDistrict` interface for ancestry tracking
- Added `resolveLucaAncestor()` method to walk the ancestry chain and verify it reaches a canonical district
- Added `registerDistrict()` method with full validation:
  - Snake_case key format enforcement
  - Canonical district override prevention
  - Duplicate registration prevention
  - LUCA parent existence validation
  - Multi-hop ancestry chain validation
  - Archetype inheritance from canonical ancestor
- Added `register_district` MCP tool with input schema
- Updated `createSnapshot()` to persist custom districts (only those with `luca_parent`)
- Updated `loadSnapshot()` to restore custom districts before loading memories
- Added `customDistricts` field to `MemorySnapshot` interface

### Tests (`test/luca-custom-districts.test.mjs`)

9 comprehensive tests covering:
- Valid registration with direct canonical parent
- Multi-hop LUCA chain validation (grandchild → child → canonical)
- Rejection of canonical district key override
- Rejection of invalid key format (must be snake_case)
- Rejection of unknown LUCA parent
- Rejection of duplicate registration
- Archetype inheritance from LUCA ancestor
- Cross-session persistence (snapshot save/restore)
- Memory stats inclusion of custom districts

## Testing

- All 9 new LUCA tests pass
- Full test suite (61 tests) passes with zero regressions
- Build succeeds with no TypeScript errors

Closes #58