### PR TITLE
feat: add INTERNAL_ERROR to NM_ERRORS for improved error handling

### DIFF
--- a/src/core/error-codes.ts
+++ b/src/core/error-codes.ts
@@ -1,5 +1,7 @@
 import { INTERNAL_ERROR } from "@modelcontextprotocol/sdk/spec.types.js";
 
+export const MCP_INTERNAL_ERROR_CODE = INTERNAL_ERROR;
+
 export const NM_ERRORS = {
   STORAGE_PATH_NOT_WRITABLE: "NM_E001",
   WAL_CORRUPT_ENTRY: "NM_E002",
@@ -9,7 +11,6 @@ export const NM_ERRORS = {
   PERSISTENCE_WRITE_FAILED: "NM_E006",
   BM25_INDEX_INCONSISTENCY: "NM_E007",
   // Reserved / unassigned codes kept for long-term stability of the NM_E001–NM_E030 range.
-  INTERNAL_ERROR: INTERNAL_ERROR,
   RESERVED_008: "NM_E008",
   RESERVED_009: "NM_E009",
   WRITE_QUEUE_CAPACITY: "NM_E010",
@@ -36,9 +37,11 @@ export const NM_ERRORS = {
 } as const;
 
 export type NMErrorCode = (typeof NM_ERRORS)[keyof typeof NM_ERRORS];
+export type ProtocolErrorCode = typeof MCP_INTERNAL_ERROR_CODE;
+export type McpErrorCode = NMErrorCode | ProtocolErrorCode;
 
 export interface McpErrorShape {
-  code: NMErrorCode;
+  code: McpErrorCode;
   message: string;
   recovery: string;
 }
@@ -55,7 +58,7 @@ export class NMError extends Error {
   }
 }
 
-export function formatMcpError(code: NMErrorCode, message: string, recovery: string): McpErrorShape {
+export function formatMcpError(code: McpErrorCode, message: string, recovery: string): McpErrorShape {
   return {
     code,
     message,

--- a/src/core/error-codes.ts
+++ b/src/core/error-codes.ts
@@ -1,3 +1,5 @@
+import { INTERNAL_ERROR } from "@modelcontextprotocol/sdk/spec.types.js";
+
 export const NM_ERRORS = {
   STORAGE_PATH_NOT_WRITABLE: "NM_E001",
   WAL_CORRUPT_ENTRY: "NM_E002",
@@ -7,6 +9,7 @@ export const NM_ERRORS = {
   PERSISTENCE_WRITE_FAILED: "NM_E006",
   BM25_INDEX_INCONSISTENCY: "NM_E007",
   // Reserved / unassigned codes kept for long-term stability of the NM_E001–NM_E030 range.
+  INTERNAL_ERROR: INTERNAL_ERROR,
   RESERVED_008: "NM_E008",
   RESERVED_009: "NM_E009",
   WRITE_QUEUE_CAPACITY: "NM_E010",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { resolvePersistenceLocation } from "./core/persistence.js";
 import { AsyncMutex } from "./core/async-mutex.js";
 import { LoopTelemetryTracker } from "./core/loop-telemetry.js";
 import {
+  MCP_INTERNAL_ERROR_CODE,
   NM_ERRORS,
   asMcpErrorShape,
   createNMError,
@@ -5584,7 +5585,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           "List sessions failed",
           error,
           formatMcpError(
-            NM_ERRORS.INTERNAL_ERROR,
+            MCP_INTERNAL_ERROR_CODE,
             "Unable to list sessions.",
             "Retry list_sessions; if the problem persists, inspect server and storage health.",
           ),

--- a/test/error-codes.test.mjs
+++ b/test/error-codes.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  MCP_INTERNAL_ERROR_CODE,
   NM_ERRORS,
   asMcpErrorShape,
   createNMError,
@@ -65,4 +66,23 @@ test("formats MCP error results with code, message, and recovery", () => {
     }],
     isError: true,
   });
+});
+
+test("supports protocol internal error code without widening NM_E namespace", () => {
+  const error = formatMcpError(
+    MCP_INTERNAL_ERROR_CODE,
+    "Internal failure.",
+    "Retry and inspect server logs if the problem persists.",
+  );
+
+  assert.deepEqual(error, {
+    code: MCP_INTERNAL_ERROR_CODE,
+    message: "Internal failure.",
+    recovery: "Retry and inspect server logs if the problem persists.",
+  });
+
+  assert.equal(
+    formatMcpErrorText("List sessions failed", error),
+    `❌ List sessions failed\nCode: ${MCP_INTERNAL_ERROR_CODE}\nMessage: Internal failure.\nRecovery: Retry and inspect server logs if the problem persists.`,
+  );
 });


### PR DESCRIPTION

This pull request updates the `src/core/error-codes.ts` file to improve error code handling by integrating a protocol-defined internal error code. The main changes are as follows:

Error code integration:

* Imported `INTERNAL_ERROR` from the `@modelcontextprotocol/sdk/spec.types.js` package to ensure consistency with protocol-defined error codes.
* Added a new entry `INTERNAL_ERROR` to the `NM_ERRORS` object, assigning it the imported `INTERNAL_ERROR` value.