### PR TITLE
feat: kanban workflow fields and tools (Issue #112)

### DIFF
--- a/.github/agent-kit/templates/kanban-memory.instructions.md
+++ b/.github/agent-kit/templates/kanban-memory.instructions.md
@@ -9,16 +9,19 @@ Use the neurodivergent-memory MCP server as the persistent context layer for eve
 
 ---
 
-## Column → District Mapping
+## Status → District Mapping
 
-| Kanban Column | Primary District | Supporting District |
-|---|---|---|
-| **Backlog** | `vigilant_monitoring` | `practical_execution` |
-| **Ready / Groomed** | `practical_execution` | `logical_analysis` |
-| **In Progress** | `practical_execution` | `vigilant_monitoring` |
-| **In Review** | `logical_analysis` | `practical_execution` |
-| **Blocked** | `vigilant_monitoring` | `emotional_processing` |
-| **Done / Closed** | `logical_analysis` | `creative_synthesis` |
+These mappings apply to the canonical `KanbanStatus` values used by the system and grouped in `kanban_view`: `backlog`, `ready`, `in_progress`, `blocked`, and `done`.
+
+| Supported Status | Typical Board Column | Primary District | Supporting District |
+|---|---|---|---|
+| `backlog` | **Backlog** | `vigilant_monitoring` | `practical_execution` |
+| `ready` | **Ready / Groomed** | `practical_execution` | `logical_analysis` |
+| `in_progress` | **In Progress** | `practical_execution` | `vigilant_monitoring` |
+| `blocked` | **Blocked** | `vigilant_monitoring` | `emotional_processing` |
+| `done` | **Done / Closed** | `logical_analysis` | `creative_synthesis` |
+
+Additional board-specific columns such as **In Review** or **Closed / Won't Do** are out-of-band conventions not represented in `status` or `kanban_view`. If you need to preserve that distinction, record it in tags (for example, `kanban:in_review` or `resolution:wont_do`) rather than treating it as a separate `status`.
 
 ---
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,6 +2,8 @@ export type MemoryArchetype = "scholar" | "merchant" | "mystic" | "guard";
 
 export type EpistemicStatus = "draft" | "validated" | "outdated";
 
+export type KanbanStatus = "backlog" | "ready" | "in_progress" | "blocked" | "done";
+
 export type EpistemicStatusFilter = EpistemicStatus | "unset";
 
 export interface MemoryNPC {
@@ -28,6 +30,9 @@ export interface MemoryNPC {
   repeat_count?: number;
   last_similarity_score?: number;
   ping_pong_counter?: number;
+  status?: KanbanStatus;
+  current_slice?: string;
+  why_now?: string;
 }
 
 export interface DistilledArtifact {

--- a/src/index.ts
+++ b/src/index.ts
@@ -807,7 +807,6 @@ const DEFAULT_AGENT_ID = "unassigned";
 
 const VALID_EPISTEMIC_STATUSES: EpistemicStatus[] = ["draft", "validated", "outdated"];
 const KANBAN_STATUSES: KanbanStatus[] = ["backlog", "ready", "in_progress", "blocked", "done"];
-const KANBAN_STATUS_MAX_LENGTH = 20;
 
 type MemoryUpdatePayload = Partial<Pick<MemoryNPC, "content" | "tags" | "emotional_valence" | "intensity" | "district" | "epistemic_status" | "project_id" | "repeat_write_count" | "repeat_count" | "last_similarity_score" | "ping_pong_counter">> & {
   memory_agent_id?: string;
@@ -3327,11 +3326,11 @@ class NeurodivergentMemory {
     for (const s of ordered) laneMap.set(s, []);
 
     for (const m of all) {
-      const lane = m.status ?? "backlog";
-      const bucket = laneMap.get(lane);
-      if (bucket) {
-        bucket.push({ id: m.id, name: m.name, status: m.status, current_slice: m.current_slice, why_now: m.why_now, agent_id: m.agent_id, project_id: m.project_id, session_id: m.session_id });
-      }
+      const lane = m.status && ordered.includes(m.status as KanbanStatus)
+        ? (m.status as KanbanStatus)
+        : "backlog";
+      const bucket = laneMap.get(lane)!;
+      bucket.push({ id: m.id, name: m.name, status: lane, current_slice: m.current_slice, why_now: m.why_now, agent_id: m.agent_id, project_id: m.project_id, session_id: m.session_id });
     }
 
     const lanes = ordered
@@ -5298,13 +5297,20 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { content, district, tags = [], emotional_valence, intensity = 0.5, agent_id, project_id, epistemic_status, session_id, status, current_slice, why_now } = request.params.arguments as any;
 
       try {
-        if (status !== undefined && status !== null) validateKanbanStatus(status);
+        if (status === null || current_slice === null || why_now === null) {
+          throw createNMError(
+            NM_ERRORS.INPUT_VALIDATION_FAILED,
+            "store_memory does not accept null for status, current_slice, or why_now. Omit these fields or provide valid string values.",
+            "To clear kanban fields on an existing memory, use update_memory instead.",
+          );
+        }
+        if (status !== undefined) validateKanbanStatus(status);
         const normalizedAgentId = normalizeOptionalAgentId(agent_id);
         const shouldCheckWipLimit =
           configuredWipLimit > 0 &&
           district === "practical_execution" &&
           typeof normalizedAgentId === "string" &&
-          hasTaskInProgressTags(tags);
+          (hasTaskInProgressTags(tags) || status === "in_progress");
 
         let wipWarning: string | undefined;
 
@@ -5338,9 +5344,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               project_id,
               epistemic_status,
               session_id,
-              status ?? undefined,
-              current_slice ?? undefined,
-              why_now ?? undefined,
+              status,
+              current_slice,
+              why_now,
             );
           },
         );
@@ -5817,30 +5823,33 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
         validateKanbanStatus(status);
         const normalizedActorAgentId = normalizeOptionalAgentId(agent_id);
+        const targetMemory = memorySystem.getAllMemories().find((m) => m.id === memory_id);
+        const normalizedGuardrailAgentId = normalizedActorAgentId ?? normalizeOptionalAgentId(targetMemory?.agent_id);
 
         // WIP guardrail: warn when transitioning to in_progress
+        // Unified check: status field OR legacy in-progress tags
         let wipWarning: string | undefined;
         if (
           status === "in_progress" &&
           configuredWipLimit > 0 &&
-          typeof normalizedActorAgentId === "string"
+          typeof normalizedGuardrailAgentId === "string"
         ) {
           const existingInProgress = memorySystem
             .getAllMemories()
             .filter(
               (m) =>
                 m.district === "practical_execution" &&
-                m.agent_id === normalizedActorAgentId &&
-                m.status === "in_progress" &&
+                m.agent_id === normalizedGuardrailAgentId &&
+                (m.status === "in_progress" || hasTaskInProgressTags(m.tags)) &&
                 m.id !== memory_id,
             );
           if (existingInProgress.length >= configuredWipLimit) {
-            wipWarning = buildWipGuardrailWarning(normalizedActorAgentId, existingInProgress);
+            wipWarning = buildWipGuardrailWarning(normalizedGuardrailAgentId, existingInProgress);
             logger.warn(
               {
                 toolName: "update_status",
                 code: NM_ERRORS.WIP_LIMIT_EXCEEDED,
-                agentId: normalizedActorAgentId,
+                agentId: normalizedGuardrailAgentId,
                 limit: configuredWipLimit,
                 currentInProgressCount: existingInProgress.length,
               },

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ import {
   mcpErrorResult,
   type McpErrorShape,
 } from "./core/error-codes.js";
-import type { DistilledArtifact, EpistemicStatus, EpistemicStatusFilter, MemoryArchetype, MemoryNPC } from "./core/types.js";
+import type { DistilledArtifact, EpistemicStatus, EpistemicStatusFilter, KanbanStatus, MemoryArchetype, MemoryNPC } from "./core/types.js";
 
 function resolveServerPackageInfo(): { name: string; version: string } {
   try {
@@ -806,11 +806,16 @@ const SESSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/;
 const DEFAULT_AGENT_ID = "unassigned";
 
 const VALID_EPISTEMIC_STATUSES: EpistemicStatus[] = ["draft", "validated", "outdated"];
+const KANBAN_STATUSES: KanbanStatus[] = ["backlog", "ready", "in_progress", "blocked", "done"];
+const KANBAN_STATUS_MAX_LENGTH = 20;
 
 type MemoryUpdatePayload = Partial<Pick<MemoryNPC, "content" | "tags" | "emotional_valence" | "intensity" | "district" | "epistemic_status" | "project_id" | "repeat_write_count" | "repeat_count" | "last_similarity_score" | "ping_pong_counter">> & {
   memory_agent_id?: string;
   project_id?: string | null;
   session_id?: string | null;
+  status?: KanbanStatus | null;
+  current_slice?: string | null;
+  why_now?: string | null;
 };
 
 interface WalEntry {
@@ -2544,7 +2549,10 @@ class NeurodivergentMemory {
     agent_id?: string,
     project_id?: string,
     epistemic_status?: EpistemicStatus,
-    session_id?: string
+    session_id?: string,
+    status?: KanbanStatus,
+    current_slice?: string,
+    why_now?: string,
   ): StoreMemoryResult {
     const registeredDistrict = this.getRegisteredDistrict(district);
     let normalizedProjectId: string | undefined = undefined;
@@ -2649,6 +2657,9 @@ class NeurodivergentMemory {
       intensity,
       epistemic_status: resolvedEpistemicStatus,
       last_similarity_score: similarityScore,
+      ...(status !== undefined ? { status } : {}),
+      ...(current_slice !== undefined ? { current_slice } : {}),
+      ...(why_now !== undefined ? { why_now } : {}),
     };
 
     this.ensureCapacityForInsert();
@@ -2846,6 +2857,27 @@ class NeurodivergentMemory {
         delete memory.session_id;
       } else if (updates.session_id !== undefined) {
         memory.session_id = normalizeSessionId(updates.session_id);
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, "status")) {
+      if (updates.status === null) {
+        delete memory.status;
+      } else if (updates.status !== undefined) {
+        memory.status = updates.status;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, "current_slice")) {
+      if (updates.current_slice === null) {
+        delete memory.current_slice;
+      } else if (updates.current_slice !== undefined) {
+        memory.current_slice = updates.current_slice;
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, "why_now")) {
+      if (updates.why_now === null) {
+        delete memory.why_now;
+      } else if (updates.why_now !== undefined) {
+        memory.why_now = updates.why_now;
       }
     }
 
@@ -3270,6 +3302,43 @@ class NeurodivergentMemory {
       .sort((a, b) => b[1] - a[1])
       .map(([session_id, count]) => ({ session_id, count }));
     return { sessions, total: sessions.length };
+  }
+
+  kanbanView(opts: {
+    agent_id?: string;
+    project_id?: string;
+    session_id?: string;
+  } = {}): { lanes: { status: KanbanStatus; memories: Pick<MemoryNPC, "id" | "name" | "status" | "current_slice" | "why_now" | "agent_id" | "project_id" | "session_id">[] }[]; total: number } {
+    const { agent_id, project_id, session_id } = opts;
+    const normalizedAgentId = agent_id ? normalizeOptionalAgentId(agent_id) : undefined;
+    const normalizedProjectId = project_id ? normalizeProjectId(project_id) : undefined;
+    const normalizedSessionId = session_id ? normalizeSessionId(session_id) : undefined;
+
+    const all = Object.values(this.memories).filter((m) => {
+      if (m.district !== "practical_execution") return false;
+      if (normalizedAgentId !== undefined && m.agent_id !== normalizedAgentId) return false;
+      if (normalizedProjectId !== undefined && m.project_id !== normalizedProjectId) return false;
+      if (normalizedSessionId !== undefined && m.session_id !== normalizedSessionId) return false;
+      return true;
+    });
+
+    const ordered: KanbanStatus[] = ["in_progress", "blocked", "ready", "backlog", "done"];
+    const laneMap = new Map<KanbanStatus, Pick<MemoryNPC, "id" | "name" | "status" | "current_slice" | "why_now" | "agent_id" | "project_id" | "session_id">[]>();
+    for (const s of ordered) laneMap.set(s, []);
+
+    for (const m of all) {
+      const lane = m.status ?? "backlog";
+      const bucket = laneMap.get(lane);
+      if (bucket) {
+        bucket.push({ id: m.id, name: m.name, status: m.status, current_slice: m.current_slice, why_now: m.why_now, agent_id: m.agent_id, project_id: m.project_id, session_id: m.session_id });
+      }
+    }
+
+    const lanes = ordered
+      .filter((s) => (laneMap.get(s)?.length ?? 0) > 0)
+      .map((s) => ({ status: s, memories: laneMap.get(s)! }));
+
+    return { lanes, total: all.length };
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────
@@ -4152,6 +4221,16 @@ function validateSessionId(sessionId: string, fieldPath = "session_id"): void {
   }
 }
 
+function validateKanbanStatus(status: string): asserts status is KanbanStatus {
+  if (!KANBAN_STATUSES.includes(status as KanbanStatus)) {
+    throw createNMError(
+      NM_ERRORS.INPUT_VALIDATION_FAILED,
+      `Invalid status: "${status}". Expected one of: ${KANBAN_STATUSES.join(", ")}.`,
+      `Provide a valid kanban status: ${KANBAN_STATUSES.join(", ")}.`,
+    );
+  }
+}
+
 function boundedLevenshteinDistance(left: string, right: string, maxDistance: number): number | undefined {
   if (Math.abs(left.length - right.length) > maxDistance) {
     return undefined;
@@ -4533,6 +4612,19 @@ function buildRegisteredToolDescriptors(): ToolDescriptor[] {
               type: "string",
               enum: ["draft", "validated", "outdated"],
               description: "Optional epistemic status for planning memories"
+            },
+            status: {
+              type: "string",
+              enum: ["backlog", "ready", "in_progress", "blocked", "done"],
+              description: "Optional kanban status for workflow tracking (practical_execution recommended)"
+            },
+            current_slice: {
+              type: "string",
+              description: "Optional sub-task or slice currently being worked on"
+            },
+            why_now: {
+              type: "string",
+              description: "Optional reason this task is being prioritized now"
             }
           },
           required: ["content", "district"]
@@ -4622,6 +4714,19 @@ function buildRegisteredToolDescriptors(): ToolDescriptor[] {
               type: "string",
               enum: ["draft", "validated", "outdated"],
               description: "New epistemic status (optional)"
+            },
+            status: {
+              type: ["string", "null"],
+              enum: ["backlog", "ready", "in_progress", "blocked", "done", null],
+              description: "New kanban status (optional); pass null to clear"
+            },
+            current_slice: {
+              type: ["string", "null"],
+              description: "New current sub-task slice (optional); pass null to clear"
+            },
+            why_now: {
+              type: ["string", "null"],
+              description: "New prioritization reason (optional); pass null to clear"
             }
           },
           required: ["memory_id"]
@@ -5024,6 +5129,58 @@ function buildRegisteredToolDescriptors(): ToolDescriptor[] {
           },
           required: ["key", "name", "description", "luca_parent"]
         }
+      },
+      {
+        name: "kanban_view",
+        description: "Show a kanban board view of practical_execution memories, grouped by status (in_progress, blocked, ready, backlog, done). Useful for workflow status checks and WIP monitoring.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            agent_id: {
+              type: "string",
+              description: "Optional agent_id filter to show only this agent's tasks"
+            },
+            project_id: {
+              type: "string",
+              description: "Optional project_id filter"
+            },
+            session_id: {
+              type: "string",
+              description: "Optional session_id filter"
+            }
+          }
+        }
+      },
+      {
+        name: "update_status",
+        description: "Lightweight tool to transition a memory's kanban status and optionally set current_slice (the active sub-task) and why_now (the prioritization reason). Enforces WIP guardrail when transitioning to in_progress.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            memory_id: {
+              type: "string",
+              description: "ID of the memory to update"
+            },
+            status: {
+              type: "string",
+              enum: ["backlog", "ready", "in_progress", "blocked", "done"],
+              description: "New kanban status"
+            },
+            current_slice: {
+              type: ["string", "null"],
+              description: "Optional sub-task or slice currently being worked on. Pass null to clear."
+            },
+            why_now: {
+              type: ["string", "null"],
+              description: "Optional reason this task is being prioritized now. Pass null to clear."
+            },
+            agent_id: {
+              type: "string",
+              description: "Optional caller agent identifier for WIP guardrail attribution"
+            }
+          },
+          required: ["memory_id", "status"]
+        }
       }
     ];
 }
@@ -5071,7 +5228,10 @@ function toolWhenToUseHint(toolName: string): string {
     case "list_memories":
     case "memory_stats":
     case "list_sessions":
+    case "kanban_view":
       return "Use for broad inventory, pagination, or aggregate status checks across the graph.";
+    case "update_status":
+      return "Use to transition a memory's kanban status and optionally set current_slice or why_now.";
     case "import_memories":
       return "Use for bulk import from inline entries or a snapshot file, with optional dry-run validation.";
     case "storage_diagnostics":
@@ -5135,9 +5295,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return buildListToolsResult();
     }
     case "store_memory": {
-      const { content, district, tags = [], emotional_valence, intensity = 0.5, agent_id, project_id, epistemic_status, session_id } = request.params.arguments as any;
+      const { content, district, tags = [], emotional_valence, intensity = 0.5, agent_id, project_id, epistemic_status, session_id, status, current_slice, why_now } = request.params.arguments as any;
 
       try {
+        if (status !== undefined && status !== null) validateKanbanStatus(status);
         const normalizedAgentId = normalizeOptionalAgentId(agent_id);
         const shouldCheckWipLimit =
           configuredWipLimit > 0 &&
@@ -5177,6 +5338,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               project_id,
               epistemic_status,
               session_id,
+              status ?? undefined,
+              current_slice ?? undefined,
+              why_now ?? undefined,
             );
           },
         );
@@ -5195,7 +5359,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return {
           content: [{
             type: "text",
-            text: `🧠 Stored memory "${memory.name}" in ${memorySystem.getAllDistricts().find(d => d.name.toLowerCase().replace(/\s+/g, '_') === district)?.name || district}\nID: ${memory.id}\nArchetype: ${memory.archetype}\nAgent: ${memory.agent_id ?? "unassigned"}\nProject: ${memory.project_id ?? "unset"}\nSession: ${memory.session_id ?? "unset"}\nEpistemic status: ${memory.epistemic_status ?? "unset"}\n${repeatLines}${warningLine}${repeatWarningLine}${cooldownLine}`
+            text: `🧠 Stored memory "${memory.name}" in ${memorySystem.getAllDistricts().find(d => d.name.toLowerCase().replace(/\s+/g, '_') === district)?.name || district}\nID: ${memory.id}\nArchetype: ${memory.archetype}\nAgent: ${memory.agent_id ?? "unassigned"}\nProject: ${memory.project_id ?? "unset"}\nSession: ${memory.session_id ?? "unset"}\nStatus: ${memory.status ?? "unset"}\nEpistemic status: ${memory.epistemic_status ?? "unset"}\n${repeatLines}${warningLine}${repeatWarningLine}${cooldownLine}`
           }]
         };
       } catch (error) {
@@ -5243,8 +5407,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
 
     case "update_memory": {
-      const { memory_id, content, district, tags, emotional_valence, intensity, epistemic_status, project_id, session_id, actor_district, agent_id, memory_agent_id } = request.params.arguments as any;
+      const { memory_id, content, district, tags, emotional_valence, intensity, epistemic_status, project_id, session_id, actor_district, agent_id, memory_agent_id, status, current_slice, why_now } = request.params.arguments as any;
       try {
+        if (status !== undefined && status !== null) validateKanbanStatus(status);
         const normalizedActorAgentId = normalizeOptionalAgentId(agent_id);
         const updates: MemoryUpdatePayload = {};
         if (content !== undefined) updates.content = content;
@@ -5256,6 +5421,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (memory_agent_id !== undefined) updates.memory_agent_id = memory_agent_id;
         if (project_id !== undefined) updates.project_id = project_id;
         if (session_id !== undefined) updates.session_id = session_id;
+        if (status !== undefined) updates.status = status;
+        if (current_slice !== undefined) updates.current_slice = current_slice;
+        if (why_now !== undefined) updates.why_now = why_now;
 
         const updateResult = await runMutatingTool(
           "update_memory",
@@ -5268,7 +5436,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return {
           content: [{
             type: "text",
-            text: `✏️ Updated memory "${memory.name}" (${memory_id})\nDistrict: ${memory.district}\nAgent: ${memory.agent_id ?? DEFAULT_AGENT_ID}\nProject: ${memory.project_id ?? 'unset'}\nSession: ${memory.session_id ?? 'unset'}\nEpistemic status: ${memory.epistemic_status ?? 'unset'}\nTags: ${memory.tags.join(', ')}${cooldownLine}`
+            text: `✏️ Updated memory "${memory.name}" (${memory_id})\nDistrict: ${memory.district}\nAgent: ${memory.agent_id ?? DEFAULT_AGENT_ID}\nProject: ${memory.project_id ?? 'unset'}\nSession: ${memory.session_id ?? 'unset'}\nStatus: ${memory.status ?? 'unset'}\nEpistemic status: ${memory.epistemic_status ?? 'unset'}\nTags: ${memory.tags.join(', ')}${cooldownLine}`
           }]
         };
       } catch (error) {
@@ -5588,6 +5756,124 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             MCP_INTERNAL_ERROR_CODE,
             "Unable to list sessions.",
             "Retry list_sessions; if the problem persists, inspect server and storage health.",
+          ),
+        );
+      }
+    }
+
+    case "kanban_view": {
+      try {
+        const { agent_id, project_id, session_id } = request.params.arguments as any;
+        const result = memorySystem.kanbanView({ agent_id, project_id, session_id });
+        if (result.total === 0) {
+          return { content: [{ type: "text", text: `📋 Kanban view: no practical_execution memories found.` }] };
+        }
+        const laneText = result.lanes
+          .map((lane) => {
+            const header = `## ${lane.status.toUpperCase()} (${lane.memories.length})`;
+            const rows = lane.memories
+              .map((m) => {
+                const slice = m.current_slice ? `\n    slice: ${m.current_slice}` : "";
+                const why = m.why_now ? `\n    why_now: ${m.why_now}` : "";
+                return `  • [${m.id}] ${m.name}${slice}${why}`;
+              })
+              .join("\n");
+            return `${header}\n${rows}`;
+          })
+          .join("\n\n");
+        return {
+          content: [{ type: "text", text: `📋 Kanban View (${result.total} memories)\n\n${laneText}` }],
+        };
+      } catch (error) {
+        return toolErrorResult(
+          "kanban_view",
+          "Kanban view failed",
+          error,
+          formatMcpError(
+            MCP_INTERNAL_ERROR_CODE,
+            "Unable to build kanban view.",
+            "Retry kanban_view; if the problem persists, inspect server and storage health.",
+          ),
+        );
+      }
+    }
+
+    case "update_status": {
+      const { memory_id, status, current_slice, why_now, agent_id } = request.params.arguments as any;
+      try {
+        if (!memory_id) {
+          throw createNMError(
+            NM_ERRORS.INPUT_VALIDATION_FAILED,
+            "memory_id is required.",
+            "Provide a valid memory_id and retry update_status.",
+          );
+        }
+        if (status === undefined || status === null) {
+          throw createNMError(
+            NM_ERRORS.INPUT_VALIDATION_FAILED,
+            "status is required for update_status.",
+            `Provide a valid status: ${KANBAN_STATUSES.join(", ")}.`,
+          );
+        }
+        validateKanbanStatus(status);
+        const normalizedActorAgentId = normalizeOptionalAgentId(agent_id);
+
+        // WIP guardrail: warn when transitioning to in_progress
+        let wipWarning: string | undefined;
+        if (
+          status === "in_progress" &&
+          configuredWipLimit > 0 &&
+          typeof normalizedActorAgentId === "string"
+        ) {
+          const existingInProgress = memorySystem
+            .getAllMemories()
+            .filter(
+              (m) =>
+                m.district === "practical_execution" &&
+                m.agent_id === normalizedActorAgentId &&
+                m.status === "in_progress" &&
+                m.id !== memory_id,
+            );
+          if (existingInProgress.length >= configuredWipLimit) {
+            wipWarning = buildWipGuardrailWarning(normalizedActorAgentId, existingInProgress);
+            logger.warn(
+              {
+                toolName: "update_status",
+                code: NM_ERRORS.WIP_LIMIT_EXCEEDED,
+                agentId: normalizedActorAgentId,
+                limit: configuredWipLimit,
+                currentInProgressCount: existingInProgress.length,
+              },
+              "WIP guardrail warning emitted",
+            );
+          }
+        }
+
+        const updates: MemoryUpdatePayload = { status };
+        if (current_slice !== undefined) updates.current_slice = current_slice;
+        if (why_now !== undefined) updates.why_now = why_now;
+
+        const updateResult = await runMutatingTool(
+          "update_status",
+          () => memorySystem.updateMemory(memory_id, updates, { agent_id: normalizedActorAgentId }),
+        );
+        const memory = updateResult.memory;
+        const wipLine = wipWarning ? `\n${wipWarning}` : "";
+        return {
+          content: [{
+            type: "text",
+            text: `📋 Status updated for "${memory.name}" (${memory_id})\nStatus: ${memory.status ?? "unset"}\nCurrent slice: ${memory.current_slice ?? "unset"}\nWhy now: ${memory.why_now ?? "unset"}${wipLine}`,
+          }],
+        };
+      } catch (error) {
+        return toolErrorResult(
+          "update_status",
+          "Update status failed",
+          error,
+          formatMcpError(
+            NM_ERRORS.INPUT_VALIDATION_FAILED,
+            "Update status request was invalid.",
+            `Provide a valid memory_id and status (${KANBAN_STATUSES.join(", ")}), then retry update_status.`,
           ),
         );
       }

--- a/templates/agent-kit/kanban-memory.instructions.md
+++ b/templates/agent-kit/kanban-memory.instructions.md
@@ -1,0 +1,216 @@
+---
+applyTo: "**"
+description: "Kanban workflow integration for neurodivergent-memory MCP. Binds board lifecycle events (card creation, column transitions, blockers, and completion) to persistent memory writes so the agent maintains durable project context across every session."
+---
+
+# Kanban ↔ neurodivergent-memory Integration
+
+Use the neurodivergent-memory MCP server as the persistent context layer for every Kanban board interaction. Each column transition, card event, or blockers update is a memory-write trigger — not just a board state change.
+
+---
+
+## Column → District Mapping
+
+| Kanban Column | Primary District | Supporting District |
+|---|---|---|
+| **Backlog** | `vigilant_monitoring` | `practical_execution` |
+| **Ready / Groomed** | `practical_execution` | `logical_analysis` |
+| **In Progress** | `practical_execution` | `vigilant_monitoring` |
+| **In Review** | `logical_analysis` | `practical_execution` |
+| **Blocked** | `vigilant_monitoring` | `emotional_processing` |
+| **Done / Closed** | `logical_analysis` | `creative_synthesis` |
+
+---
+
+## Session Baseline (run at the start of every Kanban session)
+
+1. `memory_stats` — confirm the memory graph is reachable and note total counts.
+2. `search_memories` with query `"kanban board status current sprint"` — pull active task context.
+3. `search_memories` with query `"blocked risk constraint"` — surface any open `vigilant_monitoring` entries.
+4. Review retrieved memories before touching any card or making any board decision.
+
+---
+
+## Card Lifecycle Memory Contract
+
+### Card Created (Backlog entry)
+
+Store a memory in `practical_execution` (or `vigilant_monitoring` if the card represents a known risk):
+
+```
+district: practical_execution
+tags: ["topic:<feature-area>", "scope:project", "kind:task", "layer:implementation", "kanban:backlog"]
+content: "Card '<title>' added to backlog. Goal: <goal>. Acceptance criteria: <criteria>. Initial priority rationale: <why-now-or-why-deferred>."
+epistemic_status: draft
+```
+
+Connect to any existing memories for the same feature area with `connect_memories`.
+
+### Card Moved: Backlog → Ready
+
+Update the existing card memory with `update_memory`:
+
+```
+tags: [...existing, "kanban:ready"]
+epistemic_status: validated
+content: append "Groomed <date>. Definition of ready confirmed: <criteria met>. Assigned to: <agent/person>."
+```
+
+### Card Moved: Ready → In Progress
+
+Update the card memory:
+
+```
+tags: [...existing, "kanban:in-progress"]
+content: append "Work started <date>. Implementation plan: <brief plan>. First action: <next step>."
+```
+
+Create a linked plan memory in `practical_execution` if the implementation plan is non-trivial:
+
+```
+district: practical_execution
+tags: ["topic:<feature-area>", "scope:project", "kind:task", "layer:implementation", "kanban:plan"]
+content: "Implementation plan for '<title>': <numbered steps>. Estimated scope: <size>. Key risks: <risks>."
+```
+
+Connect plan memory to card memory with `connect_memories`.
+
+### Card Moved: In Progress → In Review
+
+Update the card memory:
+
+```
+tags: [...existing, "kanban:in-review"]
+content: append "Submitted for review <date>. Changes: <files/areas>. Reviewer: <name/agent>. Self-review findings: <none or list>."
+```
+
+Store a `logical_analysis` memory for any architecture or design decisions made during implementation:
+
+```
+district: logical_analysis
+tags: ["topic:<feature-area>", "scope:project", "kind:decision", "layer:architecture"]
+content: "Decision made during '<title>': <decision>. Rationale: <why>. Rejected alternatives: <alternatives>."
+```
+
+Connect the decision memory to the card memory.
+
+### Card Moved: In Review → Done
+
+Update the card memory:
+
+```
+tags: [...existing, "kanban:done"]
+epistemic_status: validated
+content: append "Completed <date>. Validation: <test results / review outcome>. Merged/deployed: <ref>."
+```
+
+Store a `logical_analysis` or `creative_synthesis` memory capturing the durable lesson:
+
+```
+district: logical_analysis   # or creative_synthesis for cross-domain insights
+tags: ["topic:<feature-area>", "scope:global", "kind:insight", "layer:architecture", "persistence:durable"]
+content: "Lesson from '<title>': <reusable principle or pattern>. Applies when: <context>. Anti-pattern avoided: <what not to do>."
+```
+
+Connect the lesson memory to both the card memory and any related prior reasoning memories.
+
+### Card Moved to Blocked
+
+Store a new memory in `vigilant_monitoring` (do not simply update the card):
+
+```
+district: vigilant_monitoring
+tags: ["topic:<feature-area>", "scope:project", "kind:task", "layer:debugging", "kanban:blocked"]
+content: "BLOCKER on '<title>' since <date>. Blocking reason: <reason>. Impact: <impact>. Recovery options: <options>. Owner of unblock: <person/agent>."
+intensity: 0.8
+emotional_valence: -0.5
+```
+
+Connect to the card memory with `connect_memories`.
+
+When the blocker resolves, update the blocker memory (`epistemic_status: outdated`) and add a resolution note. Move the card back with a standard column-transition write.
+
+### Card Closed / Won't Do
+
+Update the card memory:
+
+```
+tags: [...existing, "kanban:closed"]
+epistemic_status: outdated
+content: append "Closed <date>. Reason: <rationale for closing without completing>. Future reference: <any conditions under which this should be revisited>."
+```
+
+---
+
+## Sprint / Cycle Cadence
+
+### Sprint Start
+
+1. `search_memories` with query `"sprint backlog ready priority"` — confirm the queue is loaded.
+2. For each card moving from Ready → In Progress, execute the card transition write above.
+3. Store a sprint-scope planning memory:
+
+```
+district: practical_execution
+tags: ["topic:sprint", "scope:project", "kind:task", "layer:implementation", "kanban:sprint-plan"]
+content: "Sprint <number/date> plan. Cards in scope: <list>. Goal: <sprint goal>. Known risks: <risks>. Success criteria: <criteria>."
+```
+
+### Sprint End / Retrospective
+
+1. `search_memories` with query `"kanban done sprint lesson"` — pull completed card memories.
+2. Store a retrospective memory:
+
+```
+district: creative_synthesis
+tags: ["topic:sprint-retro", "scope:project", "kind:insight", "layer:architecture", "kanban:retro"]
+content: "Sprint <number/date> retrospective. Completed: <count> cards. Carried over: <count>. What worked: <list>. What to change: <list>. Durable principle: <key insight>."
+```
+
+Connect the retro memory to card memories for Done items and to any `vigilant_monitoring` memories for persistent blockers.
+
+---
+
+## Canonical Tag Schema for Kanban Memories
+
+Always include tags from each namespace plus the `kanban:X` status tag:
+
+| Namespace | Kanban values |
+|---|---|
+| `kanban:X` | `backlog`, `ready`, `in-progress`, `in-review`, `blocked`, `done`, `closed`, `sprint-plan`, `retro` |
+| `topic:X` | Feature area, epic, or domain (e.g., `topic:authentication`, `topic:onboarding`) |
+| `scope:X` | `scope:project` for card-level, `scope:global` for durable lessons |
+| `kind:X` | `kind:task` (card), `kind:decision` (arch choice), `kind:insight` (lesson) |
+| `layer:X` | `layer:implementation` (tasks), `layer:architecture` (decisions), `layer:debugging` (blockers) |
+| `persistence:X` | `persistence:durable` for reusable lessons, `persistence:ephemeral` for sprint-only entries |
+
+---
+
+## Memory Quality Guardrails
+
+- **No status-only writes.** A card transition memory must explain *why* the card moved, not just *that* it moved. "Moved to In Progress" is not a memory. "Started work on auth refresh because token expiry was causing silent logouts in prod (P1)" is.
+- **Blockers get their own memory node.** Do not fold blocker context into the card memory — create a `vigilant_monitoring` node and connect it. This makes blockers searchable and traversable independently.
+- **Done ≠ closed.** Completing a card is a moment to extract a durable lesson. If nothing is worth capturing in `logical_analysis` or `creative_synthesis`, ask why — the answer is usually itself worth storing.
+- **Connect, don't duplicate.** If a card implements a pattern already recorded in memory, connect to that memory rather than re-stating the pattern. Use `traverse_from` or `related_to` to find candidates.
+- **Prefer `update_memory` over new nodes** when continuing an active card thread. Create a new node only for genuinely new concerns (e.g., a fresh blocker or a cross-sprint lesson).
+
+---
+
+## Minimum MCP Sequence for a Card Transition
+
+1. `search_memories` — retrieve card and related context.
+2. `update_memory` (existing card node) — record the transition event and rationale.
+3. `store_memory` — create supporting node (plan, decision, blocker, or lesson) if needed.
+4. `connect_memories` — link the supporting node to the card node.
+5. (At session end) hand-off `store_memory` in `practical_execution` — summarize current board state, next actions, and key open risks.
+
+---
+
+## Installation Handshake
+
+If neurodivergent-memory MCP is not installed or not connected:
+
+1. Ask the user which setup policy applies: `prompt-first` or `auto-setup`.
+2. If unspecified, default to `prompt-first`.
+3. If approved, run: `npm install -g neurodivergent-memory`
+4. Confirm with `memory_stats` before proceeding with any board operation.

--- a/templates/agent-kit/kanban-memory.instructions.md
+++ b/templates/agent-kit/kanban-memory.instructions.md
@@ -9,16 +9,19 @@ Use the neurodivergent-memory MCP server as the persistent context layer for eve
 
 ---
 
-## Column → District Mapping
+## Status → District Mapping
 
-| Kanban Column | Primary District | Supporting District |
-|---|---|---|
-| **Backlog** | `vigilant_monitoring` | `practical_execution` |
-| **Ready / Groomed** | `practical_execution` | `logical_analysis` |
-| **In Progress** | `practical_execution` | `vigilant_monitoring` |
-| **In Review** | `logical_analysis` | `practical_execution` |
-| **Blocked** | `vigilant_monitoring` | `emotional_processing` |
-| **Done / Closed** | `logical_analysis` | `creative_synthesis` |
+These mappings apply to the canonical `KanbanStatus` values used by the system and grouped in `kanban_view`: `backlog`, `ready`, `in_progress`, `blocked`, and `done`.
+
+| Supported Status | Typical Board Column | Primary District | Supporting District |
+|---|---|---|---|
+| `backlog` | **Backlog** | `vigilant_monitoring` | `practical_execution` |
+| `ready` | **Ready / Groomed** | `practical_execution` | `logical_analysis` |
+| `in_progress` | **In Progress** | `practical_execution` | `vigilant_monitoring` |
+| `blocked` | **Blocked** | `vigilant_monitoring` | `emotional_processing` |
+| `done` | **Done / Closed** | `logical_analysis` | `creative_synthesis` |
+
+Additional board-specific columns such as **In Review** or **Closed / Won't Do** are out-of-band conventions not represented in `status` or `kanban_view`. If you need to preserve that distinction, record it in tags (for example, `kanban:in_review` or `resolution:wont_do`) rather than treating it as a separate `status`.
 
 ---
 

--- a/test/kanban-fields.test.mjs
+++ b/test/kanban-fields.test.mjs
@@ -107,6 +107,17 @@ describe("kanban fields: store_memory with status", () => {
     assert.match(text, /[Ii]nvalid status/i);
   });
 
+  it("rejects null status in store_memory", async () => {
+    const res = await callTool("store_memory", {
+      content: "Task with null status",
+      district: "practical_execution",
+      tags: ["kind:task"],
+      status: null,
+    });
+    const text = getText(res);
+    assert.match(text, /does not accept null/i);
+  });
+
   it("stores a memory without status (status shows as unset)", async () => {
     const res = await callTool("store_memory", {
       content: "Backlog task without explicit status",

--- a/test/kanban-fields.test.mjs
+++ b/test/kanban-fields.test.mjs
@@ -1,0 +1,303 @@
+/**
+ * Tests for Issue #112: Kanban workflow fields and tools
+ * Covers: status/current_slice/why_now fields, kanban_view tool, update_status tool,
+ * WIP guardrail enforcement for in_progress transitions.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, before, after } from "node:test";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = path.resolve(__dirname, "../build/index.js");
+
+let serverProcess;
+let buffer = "";
+let seq = 0;
+
+function sendRequest(method, params = {}) {
+  const id = ++seq;
+  const msg = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+  serverProcess.stdin.write(msg + "\n");
+  return waitForResponse(id);
+}
+
+function waitForResponse(id, timeoutMs = 5000) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout waiting for response id=${id}`)), timeoutMs);
+    function tryParse() {
+      const lines = buffer.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (!line) continue;
+        try {
+          const parsed = JSON.parse(line);
+          if (parsed.id === id) {
+            clearTimeout(timer);
+            buffer = lines.slice(i + 1).join("\n");
+            serverProcess.stdout.removeListener("data", onData);
+            resolve(parsed);
+            return;
+          }
+        } catch {
+          // not valid JSON yet
+        }
+      }
+    }
+    function onData(chunk) {
+      buffer += chunk.toString();
+      tryParse();
+    }
+    serverProcess.stdout.on("data", onData);
+    tryParse();
+  });
+}
+
+async function callTool(name, args = {}) {
+  const res = await sendRequest("tools/call", { name, arguments: args });
+  return res;
+}
+
+function getText(res) {
+  return res?.result?.content?.[0]?.text ?? "";
+}
+
+before(async () => {
+  serverProcess = spawn("node", [SERVER_PATH], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, NM_PERSISTENCE_PATH: "", NM_DISABLE_WAL: "true", NM_WIP_LIMIT: "1" },
+  });
+  serverProcess.stderr.on("data", () => {}); // suppress stderr
+  await sendRequest("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "test-kanban", version: "1.0.0" },
+  });
+});
+
+after(() => {
+  serverProcess.stdin.end();
+  serverProcess.kill();
+});
+
+describe("kanban fields: store_memory with status", () => {
+  it("stores a memory with status=in_progress and shows it in output", async () => {
+    const res = await callTool("store_memory", {
+      content: "Implement kanban fields for issue #112",
+      district: "practical_execution",
+      tags: ["kind:task", "topic:kanban"],
+      status: "in_progress",
+      current_slice: "add status field to types",
+      why_now: "unblocked by session_id PR",
+    });
+    const text = getText(res);
+    assert.match(text, /Status: in_progress/);
+  });
+
+  it("rejects invalid status", async () => {
+    const res = await callTool("store_memory", {
+      content: "Task with bad status",
+      district: "practical_execution",
+      tags: [],
+      status: "flying",
+    });
+    const text = getText(res);
+    assert.match(text, /[Ii]nvalid status/i);
+  });
+
+  it("stores a memory without status (status shows as unset)", async () => {
+    const res = await callTool("store_memory", {
+      content: "Backlog task without explicit status",
+      district: "practical_execution",
+      tags: ["kind:task"],
+    });
+    const text = getText(res);
+    assert.match(text, /Status: unset/);
+  });
+});
+
+describe("kanban_view tool", () => {
+  it("returns memories grouped by lane", async () => {
+    await callTool("store_memory", {
+      content: "Ready task for kanban view test",
+      district: "practical_execution",
+      tags: ["kind:task"],
+      status: "ready",
+    });
+    await callTool("store_memory", {
+      content: "Blocked task for kanban view test",
+      district: "practical_execution",
+      tags: ["kind:task"],
+      status: "blocked",
+    });
+    const res = await callTool("kanban_view", {});
+    const text = getText(res);
+    assert.match(text, /IN_PROGRESS/);
+    assert.match(text, /READY/);
+    assert.match(text, /BLOCKED/);
+    assert.match(text, /Kanban View/);
+  });
+
+  it("shows current_slice and why_now in output", async () => {
+    const res = await callTool("kanban_view", {});
+    const text = getText(res);
+    assert.match(text, /slice:/);
+    assert.match(text, /why_now:/);
+  });
+
+  it("returns empty state message when no practical_execution memories", async () => {
+    // Use a non-existent agent_id scope to get empty results
+    const res = await callTool("kanban_view", { agent_id: "nonexistent_agent_xyz_99" });
+    const text = getText(res);
+    assert.match(text, /no practical_execution memories found/i);
+  });
+});
+
+describe("update_status tool", () => {
+  let memoryId;
+
+  before(async () => {
+    const res = await callTool("store_memory", {
+      content: "Task to transition through kanban statuses",
+      district: "practical_execution",
+      tags: ["kind:task"],
+      status: "backlog",
+      agent_id: "test-agent-kanban",
+    });
+    const text = getText(res);
+    const match = text.match(/ID: (memory_\d+)/);
+    assert.ok(match, "Should extract memory ID from store response");
+    memoryId = match[1];
+  });
+
+  it("transitions from backlog to ready", async () => {
+    const res = await callTool("update_status", {
+      memory_id: memoryId,
+      status: "ready",
+    });
+    const text = getText(res);
+    assert.match(text, /Status: ready/);
+  });
+
+  it("transitions to in_progress and sets current_slice", async () => {
+    const res = await callTool("update_status", {
+      memory_id: memoryId,
+      status: "in_progress",
+      current_slice: "writing the test cases",
+      why_now: "PR is open and reviewer is waiting",
+      agent_id: "test-agent-kanban",
+    });
+    const text = getText(res);
+    assert.match(text, /Status: in_progress/);
+    assert.match(text, /Current slice: writing the test cases/);
+    assert.match(text, /Why now: PR is open and reviewer is waiting/);
+  });
+
+  it("rejects invalid status", async () => {
+    const res = await callTool("update_status", {
+      memory_id: memoryId,
+      status: "not_a_status",
+    });
+    const text = getText(res);
+    assert.match(text, /[Ii]nvalid status/i);
+  });
+
+  it("transitions to done", async () => {
+    const res = await callTool("update_status", {
+      memory_id: memoryId,
+      status: "done",
+    });
+    const text = getText(res);
+    assert.match(text, /Status: done/);
+  });
+});
+
+describe("WIP guardrail via update_status", () => {
+  let task1Id;
+  let task2Id;
+
+  before(async () => {
+    // Store first task and move to in_progress
+    const r1 = await callTool("store_memory", {
+      content: "WIP guardrail test task 1",
+      district: "practical_execution",
+      tags: ["kind:task"],
+      status: "ready",
+      agent_id: "wip-agent",
+    });
+    const m1 = getText(r1).match(/ID: (memory_\d+)/);
+    task1Id = m1?.[1];
+
+    const r2 = await callTool("store_memory", {
+      content: "WIP guardrail test task 2",
+      district: "practical_execution",
+      tags: ["kind:task"],
+      status: "ready",
+      agent_id: "wip-agent",
+    });
+    const m2 = getText(r2).match(/ID: (memory_\d+)/);
+    task2Id = m2?.[1];
+
+    // Move task1 to in_progress (uses the 1 WIP slot)
+    await callTool("update_status", {
+      memory_id: task1Id,
+      status: "in_progress",
+      agent_id: "wip-agent",
+    });
+  });
+
+  it("emits WIP guardrail warning when transitioning second task to in_progress", async () => {
+    const res = await callTool("update_status", {
+      memory_id: task2Id,
+      status: "in_progress",
+      agent_id: "wip-agent",
+    });
+    const text = getText(res);
+    // Should succeed (not blocked) but emit the warning
+    assert.match(text, /Status: in_progress/);
+    assert.match(text, /WIP guardrail/i);
+  });
+});
+
+describe("update_memory with kanban fields", () => {
+  it("updates status via update_memory", async () => {
+    const storeRes = await callTool("store_memory", {
+      content: "Task for update_memory kanban test",
+      district: "practical_execution",
+      tags: ["kind:task"],
+    });
+    const match = getText(storeRes).match(/ID: (memory_\d+)/);
+    const id = match?.[1];
+    assert.ok(id);
+
+    const updateRes = await callTool("update_memory", {
+      memory_id: id,
+      status: "in_progress",
+      current_slice: "slice via update_memory",
+      why_now: "because testing",
+    });
+    const text = getText(updateRes);
+    assert.match(text, /Status: in_progress/);
+  });
+
+  it("clears status by passing null", async () => {
+    const storeRes = await callTool("store_memory", {
+      content: "Task to clear status",
+      district: "practical_execution",
+      tags: ["kind:task"],
+      status: "ready",
+    });
+    const match = getText(storeRes).match(/ID: (memory_\d+)/);
+    const id = match?.[1];
+    assert.ok(id);
+
+    const updateRes = await callTool("update_memory", {
+      memory_id: id,
+      status: null,
+    });
+    const text = getText(updateRes);
+    assert.match(text, /Status: unset/);
+  });
+});

--- a/test/session-id.test.mjs
+++ b/test/session-id.test.mjs
@@ -231,7 +231,7 @@ test("list_sessions returns all session IDs with counts", async () => {
     assert.ok(text.includes("list-sess-b"), `Expected normalized 'list-sess-b' in: ${text}`);
     // session A has 2 memories, should be listed first (sorted by count desc)
     assert.ok(text.includes("list-sess-a: 2 memories"), `Expected count 2 for list-sess-a in: ${text}`);
-    assert.ok(text.includes("list-sess-b: 1 memories"), `Expected count 1 for list-sess-b in: ${text}`);
+    assert.ok(text.includes("list-sess-b: 1 memory"), `Expected count 1 for list-sess-b in: ${text}`);
     assert.ok(text.includes("Sessions (2 total)"), `Expected total count in: ${text}`);
   } finally {
     server.stop();


### PR DESCRIPTION
## Summary

Implements Issue #112 — Kanban workflow fields for memory task management.

### Changes

**`src/core/types.ts`**
- New `KanbanStatus` type: `"backlog" | "ready" | "in_progress" | "blocked" | "done"`
- 3 new optional fields on `MemoryNPC`: `status`, `current_slice`, `why_now`

**`src/index.ts`**
- `kanban_view` tool: groups `practical_execution` memories into status lanes, filterable by `agent_id`, `project_id`, `session_id`
- `update_status` tool: lightweight status transition with WIP guardrail (warns when setting `in_progress` while another task is already in-progress for the same agent, respects `NM_WIP_LIMIT`)
- Extended `store_memory` and `update_memory` to accept kanban fields (with null-clearing for `update_memory`)
- `validateKanbanStatus()` helper
- Constants `KANBAN_STATUSES` and `KANBAN_STATUS_MAX_LENGTH`

**`test/kanban-fields.test.mjs`** (new)
- 13 tests across 5 suites covering all acceptance criteria

**Incidental fixes bundled in this PR (pre-existing failures on `development`):**
- `test/session-id.test.mjs`: Fixed assertion checking `"1 memories"` (should be `"1 memory"` — singular)
- `templates/agent-kit/kanban-memory.instructions.md`: Synced missing file from packaged `.github/agent-kit/templates/` to source `templates/agent-kit/`

### Test Results

```
tests 146 | suites 5 | pass 146 | fail 0 | duration_ms ~17s
```
All 146 tests pass including 13 new kanban tests.

### Design Notes

- Kanban fields are scoped to `practical_execution` district for `kanban_view` (consistent with task-oriented semantics)
- WIP guardrail on `update_status` mirrors the existing tag-based guardrail but uses authoritative `status` field
- New fields auto-persist via `deserializeMemory()` spread pattern — no schema migration required
- `current_slice` and `why_now` are clearable via `null` in `update_memory` (same null-clearing pattern as `session_id`/`project_id`)

Closes #112