### PR TITLE
feat: issue #117 VS Code marketplace packaging + companion extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ env:
   AZDO_MARKETPLACE_SERVICE_URL: https://marketplace.visualstudio.com
   AZDO_EXTENSION_MANIFEST_GLOBS: vss-extension.json
   VSCODE_EXTENSION_PACKAGE_PATH: neurodivergent-memory-vscode.vsix
+  VSIDE_EXTENSION_VSIX_GLOBS: visualstudio-extension/*.vsix
 
 jobs:
   sync_release_with_main:
@@ -568,13 +569,44 @@ jobs:
 
           echo "path=${VSCODE_EXTENSION_PACKAGE_PATH}" >> "$GITHUB_OUTPUT"
 
+      - name: Discover Visual Studio IDE extension VSIX (optional)
+        id: discover_vside_vsix
+        run: |
+          vside_globs="${VSIDE_EXTENSION_VSIX_GLOBS:-visualstudio-extension/*.vsix}"
+
+          if ! compgen -G "$vside_globs" > /dev/null; then
+            echo "No Visual Studio IDE VSIX matched '$vside_globs'; skipping Visual Studio IDE channel publish path."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          vside_vsix_path="$(ls -1 $vside_globs | head -n 1)"
+          if [ -z "$vside_vsix_path" ]; then
+            echo "Visual Studio IDE VSIX discovery matched globs but produced no file path."
+            exit 1
+          fi
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "path=$vside_vsix_path" >> "$GITHUB_OUTPUT"
+
+      - name: Visual Studio IDE channel guidance
+        if: steps.discover_vside_vsix.outputs.found == 'true'
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ### Visual Studio IDE channel
+
+          A Visual Studio IDE VSIX artifact was discovered and attached to this release. Publication of Visual Studio IDE extensions can be completed from the Marketplace publisher portal under **New extension -> Visual Studio** if fully automated publish is not configured.
+          EOF
+
       - name: Publish extension to Visual Studio Marketplace
+        id: publish_azdo_marketplace
         if: steps.package_vsix.outputs.found == 'true'
         env:
           AZURE_DEVOPS_EXT_PAT: ${{ secrets['AZURE_DEVOPS_MARKETPLACE_TOKEN'] }}
         run: |
           if [ -z "$AZURE_DEVOPS_EXT_PAT" ]; then
             echo "AZURE_DEVOPS_MARKETPLACE_TOKEN is not configured; skipping Marketplace publish."
+            echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -587,27 +619,35 @@ jobs:
             --no-wait-validation \
             --no-prompt
 
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
       - name: Publish extension to VS Code Marketplace
+        id: publish_vscode_marketplace
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           if [ -z "$VSCE_PAT" ]; then
             echo "VSCE_PAT is not configured; skipping VS Code Marketplace publish."
+            echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           npm exec --yes -- @vscode/vsce publish -p "$VSCE_PAT"
+          echo "published=true" >> "$GITHUB_OUTPUT"
 
       - name: Publish extension to Open VSX (optional)
+        id: publish_ovsx
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
           if [ -z "$OVSX_PAT" ]; then
             echo "OVSX_PAT is not configured; skipping Open VSX publish."
+            echo "published=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           npm exec --yes -- ovsx publish "${{ steps.package_vscode_vsix.outputs.path }}" -p "$OVSX_PAT"
+          echo "published=true" >> "$GITHUB_OUTPUT"
 
       - name: Pack npm artifact
         id: pack
@@ -717,6 +757,10 @@ jobs:
             assets+=("${{ steps.package_vsix.outputs.path }}")
           fi
 
+          if [ "${{ steps.discover_vside_vsix.outputs.found }}" = "true" ]; then
+            assets+=("${{ steps.discover_vside_vsix.outputs.path }}")
+          fi
+
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             gh release upload "$GITHUB_REF_NAME" \
               "${assets[@]}" \
@@ -726,3 +770,38 @@ jobs:
               "${assets[@]}" \
               --generate-notes
           fi
+
+      - name: Marketplace channel summary
+        if: always()
+        run: |
+          azdo_status="skipped"
+          vscode_status="skipped"
+          ovsx_status="skipped"
+          vside_status="not-provided"
+
+          if [ "${{ steps.publish_azdo_marketplace.outputs.published }}" = "true" ]; then
+            azdo_status="published"
+          fi
+
+          if [ "${{ steps.publish_vscode_marketplace.outputs.published }}" = "true" ]; then
+            vscode_status="published"
+          fi
+
+          if [ "${{ steps.publish_ovsx.outputs.published }}" = "true" ]; then
+            ovsx_status="published"
+          fi
+
+          if [ "${{ steps.discover_vside_vsix.outputs.found }}" = "true" ]; then
+            vside_status="artifact-attached"
+          fi
+
+          {
+            echo "### Marketplace Channel Summary"
+            echo
+            echo "| Channel | Status |"
+            echo "| --- | --- |"
+            echo "| Azure DevOps / Visual Studio Marketplace (Azure Extension) | ${azdo_status} |"
+            echo "| VS Code Marketplace | ${vscode_status} |"
+            echo "| Visual Studio IDE Marketplace | ${vside_status} |"
+            echo "| Open VSX | ${ovsx_status} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Validate VS Code extension VSIX packaging (RC gate)
         run: |
-          npm exec --yes -- @vscode/vsce package -o "${VSCODE_EXTENSION_PACKAGE_PATH}"
+          npm run package:vscode
           if [ ! -f "${VSCODE_EXTENSION_PACKAGE_PATH}" ]; then
             echo "VS Code extension packaging did not produce ${VSCODE_EXTENSION_PACKAGE_PATH}."
             exit 1
@@ -560,7 +560,7 @@ jobs:
       - name: Package VS Code extension VSIX
         id: package_vscode_vsix
         run: |
-          npm exec --yes -- @vscode/vsce package -o "${VSCODE_EXTENSION_PACKAGE_PATH}"
+          npm run package:vscode
 
           if [ ! -f "${VSCODE_EXTENSION_PACKAGE_PATH}" ]; then
             echo "VS Code extension packaging ran but no VSIX artifact was produced."
@@ -632,7 +632,7 @@ jobs:
             exit 0
           fi
 
-          npm exec --yes -- @vscode/vsce publish -p "$VSCE_PAT"
+          npm exec --yes -- @vscode/vsce publish --packagePath "${{ steps.package_vscode_vsix.outputs.path }}" -p "$VSCE_PAT"
           echo "published=true" >> "$GITHUB_OUTPUT"
 
       - name: Publish extension to Open VSX (optional)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
   AZDO_MARKETPLACE_PUBLISHER_ID: jmeyer-twg
   AZDO_MARKETPLACE_SERVICE_URL: https://marketplace.visualstudio.com
   AZDO_EXTENSION_MANIFEST_GLOBS: vss-extension.json
+  VSCODE_EXTENSION_PACKAGE_PATH: neurodivergent-memory-vscode.vsix
 
 jobs:
   sync_release_with_main:
@@ -71,6 +72,15 @@ jobs:
 
       - name: Build package
         run: npm run build
+
+      - name: Validate VS Code extension VSIX packaging (RC gate)
+        run: |
+          npm exec --yes -- @vscode/vsce package -o "${VSCODE_EXTENSION_PACKAGE_PATH}"
+          if [ ! -f "${VSCODE_EXTENSION_PACKAGE_PATH}" ]; then
+            echo "VS Code extension packaging did not produce ${VSCODE_EXTENSION_PACKAGE_PATH}."
+            exit 1
+          fi
+          echo "RC gate produced VS Code VSIX: ${VSCODE_EXTENSION_PACKAGE_PATH}"
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v4
@@ -546,6 +556,18 @@ jobs:
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "path=$vsix_path" >> "$GITHUB_OUTPUT"
 
+      - name: Package VS Code extension VSIX
+        id: package_vscode_vsix
+        run: |
+          npm exec --yes -- @vscode/vsce package -o "${VSCODE_EXTENSION_PACKAGE_PATH}"
+
+          if [ ! -f "${VSCODE_EXTENSION_PACKAGE_PATH}" ]; then
+            echo "VS Code extension packaging ran but no VSIX artifact was produced."
+            exit 1
+          fi
+
+          echo "path=${VSCODE_EXTENSION_PACKAGE_PATH}" >> "$GITHUB_OUTPUT"
+
       - name: Publish extension to Visual Studio Marketplace
         if: steps.package_vsix.outputs.found == 'true'
         env:
@@ -564,6 +586,28 @@ jobs:
             --vsix "${{ steps.package_vsix.outputs.path }}" \
             --no-wait-validation \
             --no-prompt
+
+      - name: Publish extension to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "VSCE_PAT is not configured; skipping VS Code Marketplace publish."
+            exit 0
+          fi
+
+          npm exec --yes -- @vscode/vsce publish -p "$VSCE_PAT"
+
+      - name: Publish extension to Open VSX (optional)
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          if [ -z "$OVSX_PAT" ]; then
+            echo "OVSX_PAT is not configured; skipping Open VSX publish."
+            exit 0
+          fi
+
+          npm exec --yes -- ovsx publish "${{ steps.package_vscode_vsix.outputs.path }}" -p "$OVSX_PAT"
 
       - name: Pack npm artifact
         id: pack
@@ -666,6 +710,7 @@ jobs:
             checksums.txt
             npm-package.attestation.json
             docker-image.attestation.json
+            "${{ steps.package_vscode_vsix.outputs.path }}"
           )
 
           if [ "${{ steps.package_vsix.outputs.found }}" = "true" ]; then

--- a/README.md
+++ b/README.md
@@ -354,21 +354,40 @@ the snapshot file and will warn if it detects an open WAL for the target directo
 - GitHub Actions generates **artifact attestations** for the npm tarball and the pushed container image digest
 - Tagged releases upload the npm tarball, checksums, and attestation bundles as release assets
 
-### Visual Studio Marketplace Distribution (Optional)
+### Marketplace Distribution (Optional)
 
-Tagged releases can also publish an Azure DevOps / Visual Studio Marketplace extension when an extension manifest is present.
+Tagged releases can publish extension artifacts to two different ecosystems:
 
-- Workflow env defaults:
-  - `AZDO_MARKETPLACE_PUBLISHER_ID=jmeyer-twg`
-  - `AZDO_MARKETPLACE_SERVICE_URL=https://marketplace.visualstudio.com`
-  - `AZDO_EXTENSION_MANIFEST_GLOBS=vss-extension.json`
-- Required GitHub secret for publishing:
-  - `AZURE_DEVOPS_MARKETPLACE_TOKEN` (Marketplace PAT for your publisher)
-- Behavior:
-  - If no manifest matches `AZDO_EXTENSION_MANIFEST_GLOBS`, VSIX packaging/publishing is skipped.
-  - If the PAT secret is missing, publishing is skipped without failing the rest of the release pipeline.
-  - If Marketplace publish is attempted and fails, the tagged release job fails so publication issues are visible immediately.
-  - When produced, the `.vsix` artifact is also attached to the GitHub release.
+- Azure DevOps / Visual Studio Marketplace (Azure extension manifest: `vss-extension.json`)
+- VS Code Marketplace and Open VSX (VS Code extension manifest: `package.json`)
+
+Install paths differ by client:
+
+- MCP runtime usage: run `npx neurodivergent-memory@latest`
+- VS Code UI companion extension: install from VS Code Marketplace (or Open VSX in compatible editors)
+- Azure DevOps marketplace package: install the `.vsix` into Azure DevOps extension management
+
+Workflow env defaults:
+
+- `AZDO_MARKETPLACE_PUBLISHER_ID=jmeyer-twg`
+- `AZDO_MARKETPLACE_SERVICE_URL=https://marketplace.visualstudio.com`
+- `AZDO_EXTENSION_MANIFEST_GLOBS=vss-extension.json`
+- `VSCODE_EXTENSION_PACKAGE_PATH=neurodivergent-memory-vscode.vsix`
+
+Required GitHub secrets for publishing:
+
+- `AZURE_DEVOPS_MARKETPLACE_TOKEN` for Azure DevOps / Visual Studio Marketplace publish via `tfx-cli`
+- `VSCE_PAT` for VS Code Marketplace publish via `@vscode/vsce`
+- `OVSX_PAT` for optional Open VSX publish via `ovsx`
+
+Behavior:
+
+- If no manifest matches `AZDO_EXTENSION_MANIFEST_GLOBS`, Azure VSIX packaging/publishing is skipped.
+- If `AZURE_DEVOPS_MARKETPLACE_TOKEN` is missing, Azure marketplace publish is skipped.
+- If `VSCE_PAT` is missing, VS Code Marketplace publish is skipped.
+- If `OVSX_PAT` is missing, Open VSX publish is skipped.
+- Marketplace publish failures after a publish attempt fail the tagged release job so visibility is immediate.
+- Produced `.vsix` artifacts are attached to the GitHub release.
 
 ## Development RC Channel
 

--- a/README.md
+++ b/README.md
@@ -356,10 +356,11 @@ the snapshot file and will warn if it detects an open WAL for the target directo
 
 ### Marketplace Distribution (Optional)
 
-Tagged releases can publish extension artifacts to two different ecosystems:
+Tagged releases can publish extension artifacts to three marketplace channels, plus Open VSX:
 
 - Azure DevOps / Visual Studio Marketplace (Azure extension manifest: `vss-extension.json`)
 - VS Code Marketplace and Open VSX (VS Code extension manifest: `package.json`)
+- Visual Studio IDE Marketplace (Visual Studio IDE VSIX artifact, when provided)
 
 Install paths differ by client:
 
@@ -373,6 +374,7 @@ Workflow env defaults:
 - `AZDO_MARKETPLACE_SERVICE_URL=https://marketplace.visualstudio.com`
 - `AZDO_EXTENSION_MANIFEST_GLOBS=vss-extension.json`
 - `VSCODE_EXTENSION_PACKAGE_PATH=neurodivergent-memory-vscode.vsix`
+- `VSIDE_EXTENSION_VSIX_GLOBS=visualstudio-extension/*.vsix`
 
 Required GitHub secrets for publishing:
 
@@ -386,8 +388,12 @@ Behavior:
 - If `AZURE_DEVOPS_MARKETPLACE_TOKEN` is missing, Azure marketplace publish is skipped.
 - If `VSCE_PAT` is missing, VS Code Marketplace publish is skipped.
 - If `OVSX_PAT` is missing, Open VSX publish is skipped.
+- If no Visual Studio IDE VSIX matches `VSIDE_EXTENSION_VSIX_GLOBS`, the Visual Studio IDE lane is marked `not-provided` and skipped.
+- If a Visual Studio IDE VSIX is found, it is attached to the GitHub release and the workflow emits channel guidance in the job summary.
 - Marketplace publish failures after a publish attempt fail the tagged release job so visibility is immediate.
 - Produced `.vsix` artifacts are attached to the GitHub release.
+
+The release workflow also writes a per-channel summary to the GitHub Actions job summary so publication visibility is explicit across Azure DevOps, VS Code, Visual Studio IDE, and Open VSX.
 
 ## Development RC Channel
 

--- a/docs/marketplace-overview.md
+++ b/docs/marketplace-overview.md
@@ -13,11 +13,19 @@
 
 Use this package with MCP-capable clients and agents that need long-lived context across sessions and projects.
 
+The repository also ships a thin VS Code companion extension that helps users configure the MCP server quickly.
+The extension does not replace the MCP runtime; it provides setup-oriented commands and marketplace discoverability.
+
 Quick start:
 
 ```bash
 npx neurodivergent-memory@latest init-agent-kit
 ```
+
+VS Code companion commands:
+
+- `Neurodivergent Memory: Copy MCP Config`
+- `Neurodivergent Memory: Open Setup Docs`
 
 ## Repository and docs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,11 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.2",
+        "@types/vscode": "^1.95.0",
         "typescript": "^6.0.2"
+      },
+      "engines": {
+        "vscode": "^1.95.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -86,6 +90,12 @@
       "dependencies": {
         "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.118.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
+      "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.2",
-        "@types/vscode": "^1.95.0",
+        "@types/vscode": "1.95.0",
         "typescript": "^6.0.2"
       },
       "engines": {
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.118.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.118.0.tgz",
-      "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
+      "version": "1.95.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.95.0.tgz",
+      "integrity": "sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw==",
       "dev": true
     },
     "node_modules/accepts": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "Other"
   ],
   "main": "./build/vscode/extension.js",
+  "exports": {
+    ".": "./build/index.js",
+    "./vscode-extension": "./build/vscode/extension.js"
+  },
   "activationEvents": [
     "onCommand:neurodivergentMemory.copyMcpConfig",
     "onCommand:neurodivergentMemory.openDocs"
@@ -65,7 +69,7 @@
   "scripts": {
     "bench": "npm run benchmark",
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
-    "package:vscode": "npm run build && npm exec --yes -- @vscode/vsce package -o neurodivergent-memory.vsix",
+    "package:vscode": "npm run build && node scripts/package-vscode-extension.cjs",
     "prepack": "node scripts/prepare-agent-kit.cjs",
     "sync-memories": "npm run build && node build/scripts/sync-memories.js",
     "lint": "npm run lint:code && npm run lint:md",
@@ -85,7 +89,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.2",
-    "@types/vscode": "^1.95.0",
+    "@types/vscode": "1.95.0",
     "typescript": "^6.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,34 @@
 {
   "name": "neurodivergent-memory",
+  "displayName": "Neurodivergent Memory",
   "version": "0.3.9",
   "mcpName": "io.github.jmeyer1980/neurodivergent-memory",
   "description": "A Model Context Protocol server for knowledge graphs designed around neurodivergent thinking patterns",
+  "publisher": "jmeyer1980",
+  "icon": "assets/marketplace-icon.png",
+  "engines": {
+    "vscode": "^1.95.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "main": "./build/vscode/extension.js",
+  "activationEvents": [
+    "onCommand:neurodivergentMemory.copyMcpConfig",
+    "onCommand:neurodivergentMemory.openDocs"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "neurodivergentMemory.copyMcpConfig",
+        "title": "Neurodivergent Memory: Copy MCP Config"
+      },
+      {
+        "command": "neurodivergentMemory.openDocs",
+        "title": "Neurodivergent Memory: Open Setup Docs"
+      }
+    ]
+  },
   "license": "MIT",
   "type": "module",
   "repository": {
@@ -30,11 +56,16 @@
   },
   "files": [
     "build",
-    "templates"
+    "templates",
+    "assets",
+    "docs",
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "bench": "npm run benchmark",
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
+    "package:vscode": "npm run build && npm exec --yes -- @vscode/vsce package -o neurodivergent-memory.vsix",
     "prepack": "node scripts/prepare-agent-kit.cjs",
     "sync-memories": "npm run build && node build/scripts/sync-memories.js",
     "lint": "npm run lint:code && npm run lint:md",
@@ -54,6 +85,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.2",
+    "@types/vscode": "^1.95.0",
     "typescript": "^6.0.2"
   }
 }

--- a/scripts/package-vscode-extension.cjs
+++ b/scripts/package-vscode-extension.cjs
@@ -1,0 +1,54 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execSync } = require('node:child_process');
+
+const rootDir = path.resolve(__dirname, '..');
+const sourcePackagePath = path.join(rootDir, 'package.json');
+const sourcePackage = JSON.parse(fs.readFileSync(sourcePackagePath, 'utf8'));
+
+const stagedPackage = {
+  name: sourcePackage.name,
+  displayName: sourcePackage.displayName,
+  version: sourcePackage.version,
+  publisher: sourcePackage.publisher,
+  description: sourcePackage.description,
+  license: sourcePackage.license,
+  engines: sourcePackage.engines,
+  categories: sourcePackage.categories,
+  main: sourcePackage.main,
+  activationEvents: sourcePackage.activationEvents,
+  contributes: sourcePackage.contributes,
+  icon: sourcePackage.icon,
+  repository: sourcePackage.repository,
+  homepage: sourcePackage.homepage,
+  bugs: sourcePackage.bugs
+};
+
+const stageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ndm-vscode-stage-'));
+const outputVsixPath = path.join(rootDir, 'neurodivergent-memory-vscode.vsix');
+
+function copyRelative(relPath) {
+  const src = path.join(rootDir, relPath);
+  const dst = path.join(stageDir, relPath);
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.copyFileSync(src, dst);
+}
+
+try {
+  copyRelative('build/vscode/extension.js');
+  copyRelative('assets/marketplace-icon.png');
+  copyRelative('README.md');
+  copyRelative('LICENSE');
+
+  fs.writeFileSync(path.join(stageDir, 'package.json'), `${JSON.stringify(stagedPackage, null, 2)}\n`);
+
+  execSync(`npm exec --yes -- @vscode/vsce package -o "${outputVsixPath}"`, {
+    cwd: stageDir,
+    stdio: 'inherit'
+  });
+
+  console.log(`Packaged VS Code extension VSIX: ${outputVsixPath}`);
+} finally {
+  fs.rmSync(stageDir, { recursive: true, force: true });
+}

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -1,0 +1,44 @@
+import * as vscode from 'vscode';
+
+const DOCS_URL = 'https://github.com/jmeyer1980/neurodivergent-memory#setup';
+
+function buildMcpConfigSnippet(): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        'neurodivergent-memory': {
+          command: 'npx',
+          args: ['-y', 'neurodivergent-memory@latest']
+        }
+      }
+    },
+    null,
+    2
+  );
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  const copyConfig = vscode.commands.registerCommand('neurodivergentMemory.copyMcpConfig', async () => {
+    await vscode.env.clipboard.writeText(buildMcpConfigSnippet());
+
+    const action = 'Open Setup Docs';
+    const selected = await vscode.window.showInformationMessage(
+      'Neurodivergent Memory MCP config copied to clipboard.',
+      action
+    );
+
+    if (selected === action) {
+      await vscode.env.openExternal(vscode.Uri.parse(DOCS_URL));
+    }
+  });
+
+  const openDocs = vscode.commands.registerCommand('neurodivergentMemory.openDocs', async () => {
+    await vscode.env.openExternal(vscode.Uri.parse(DOCS_URL));
+  });
+
+  context.subscriptions.push(copyConfig, openDocs);
+}
+
+export function deactivate(): void {
+  // no-op
+}

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-const DOCS_URL = 'https://github.com/jmeyer1980/neurodivergent-memory#setup';
+const DOCS_URL = 'https://github.com/jmeyer1980/neurodivergent-memory#quick-start';
 
 function buildMcpConfigSnippet(): string {
   return JSON.stringify(


### PR DESCRIPTION
## Summary
- add VS Code companion extension metadata and activation entrypoint
- add release workflow steps to package VS Code VSIX and optionally publish to VS Code Marketplace/Open VSX
- keep Azure DevOps extension packaging/publish path and attach VSIX artifacts to release
- add explicit Visual Studio IDE channel visibility in the release workflow
- address Copilot review feedback around packaging safety, artifact determinism, and Node consumer compatibility
- document marketplace strategy and install paths in README/docs

## Follow-up Fixes
- pin `@types/vscode` to `1.95.0` to match the declared engine baseline
- fix the setup docs link to the existing `#quick-start` anchor
- add an `exports` map so normal Node consumers resolve to the MCP server entrypoint
- align VSIX naming with `VSCODE_EXTENSION_PACKAGE_PATH`
- publish to VS Code Marketplace from the already-packaged VSIX artifact
- package the VS Code extension from a deterministic staged directory so the VSIX stays minimal

## Testing
- `npm run build`
- `npm test`
- `npm run package:vscode`
- `npm exec --yes -- tfx-cli extension create --manifest-globs vss-extension.json --output-path .`

Closes #117