### PR TITLE
feat: [v0.4.0] Visibility model and share_memory flow (#113)

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,6 +6,8 @@ export type KanbanStatus = "backlog" | "ready" | "in_progress" | "blocked" | "do
 
 export type EpistemicStatusFilter = EpistemicStatus | "unset";
 
+export type VisibilityLevel = "private" | "shared" | "global";
+
 export interface MemoryNPC {
   id: string;
   name: string;
@@ -33,6 +35,7 @@ export interface MemoryNPC {
   status?: KanbanStatus;
   current_slice?: string;
   why_now?: string;
+  visibility?: VisibilityLevel;
 }
 
 export interface DistilledArtifact {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ import {
   mcpErrorResult,
   type McpErrorShape,
 } from "./core/error-codes.js";
-import type { DistilledArtifact, EpistemicStatus, EpistemicStatusFilter, KanbanStatus, MemoryArchetype, MemoryNPC } from "./core/types.js";
+import type { DistilledArtifact, EpistemicStatus, EpistemicStatusFilter, KanbanStatus, MemoryArchetype, MemoryNPC, VisibilityLevel } from "./core/types.js";
 
 function resolveServerPackageInfo(): { name: string; version: string } {
   try {
@@ -999,6 +999,7 @@ const DEFAULT_AGENT_ID = "unassigned";
 
 const VALID_EPISTEMIC_STATUSES: EpistemicStatus[] = ["draft", "validated", "outdated"];
 const KANBAN_STATUSES: KanbanStatus[] = ["backlog", "ready", "in_progress", "blocked", "done"];
+const VALID_VISIBILITY_LEVELS: VisibilityLevel[] = ["private", "shared", "global"];
 
 type MemoryUpdatePayload = Partial<Pick<MemoryNPC, "content" | "tags" | "emotional_valence" | "intensity" | "district" | "epistemic_status" | "project_id" | "repeat_write_count" | "repeat_count" | "last_similarity_score" | "ping_pong_counter">> & {
   memory_agent_id?: string;
@@ -1007,6 +1008,7 @@ type MemoryUpdatePayload = Partial<Pick<MemoryNPC, "content" | "tags" | "emotion
   status?: KanbanStatus | null;
   current_slice?: string | null;
   why_now?: string | null;
+  visibility?: VisibilityLevel | null;
 };
 
 interface WalEntry {
@@ -2744,6 +2746,7 @@ class NeurodivergentMemory {
     status?: KanbanStatus,
     current_slice?: string,
     why_now?: string,
+    visibility?: VisibilityLevel,
   ): StoreMemoryResult {
     const registeredDistrict = this.getRegisteredDistrict(district);
     let normalizedProjectId: string | undefined = undefined;
@@ -2851,6 +2854,7 @@ class NeurodivergentMemory {
       ...(status !== undefined ? { status } : {}),
       ...(current_slice !== undefined ? { current_slice } : {}),
       ...(why_now !== undefined ? { why_now } : {}),
+      ...(visibility !== undefined ? { visibility } : {}),
     };
 
     this.ensureCapacityForInsert();
@@ -3071,6 +3075,13 @@ class NeurodivergentMemory {
         memory.why_now = updates.why_now;
       }
     }
+    if (Object.prototype.hasOwnProperty.call(updates, "visibility")) {
+      if (updates.visibility === null) {
+        delete memory.visibility;
+      } else if (updates.visibility !== undefined) {
+        memory.visibility = updates.visibility;
+      }
+    }
 
     this.bm25.addDocument(id, this.documentText(memory));
   }
@@ -3116,6 +3127,7 @@ class NeurodivergentMemory {
     context?: string,
     recency_weight = 0,
     session_id?: string,
+    visibility?: VisibilityLevel[],
   ): SearchMemoriesResult {
     if (recency_weight < 0 || recency_weight > 1) {
       throw createNMError(
@@ -3169,6 +3181,13 @@ class NeurodivergentMemory {
     }
     if (intensity_max !== undefined) {
       candidates = candidates.filter(m => (m.intensity ?? 0.5) <= intensity_max!);
+    }
+
+    if (visibility && visibility.length > 0) {
+      candidates = candidates.filter(m => {
+        const memVisibility = m.visibility ?? "private";
+        return visibility.includes(memVisibility);
+      });
     }
 
     const hasContext = typeof context === "string" && context.trim().length > 0;
@@ -3367,6 +3386,7 @@ class NeurodivergentMemory {
     project_id?: string,
     epistemic_statuses?: EpistemicStatusFilter[],
     session_id?: string,
+    visibility?: VisibilityLevel[],
   ): { memories: MemoryNPC[]; total: number; page: number; page_size: number; total_pages: number } {
     let all = Object.values(this.memories);
     if (district) all = all.filter(m => m.district === district);
@@ -3380,6 +3400,12 @@ class NeurodivergentMemory {
       all = all.filter(m => {
         const status = m.epistemic_status ?? "unset";
         return epistemic_statuses.includes(status);
+      });
+    }
+    if (visibility && visibility.length > 0) {
+      all = all.filter(m => {
+        const memVisibility = m.visibility ?? "private";
+        return visibility.includes(memVisibility);
       });
     }
 
@@ -3776,6 +3802,114 @@ class NeurodivergentMemory {
       distilled: distilledMemory,
       artifact,
     };
+  }
+
+  /**
+   * Share a memory by updating its visibility and recording a provenance trail.
+   * Returns the updated memory and the new provenance connection memory ID.
+   * - `target_agent_id`: the agent to whom the memory is being shared (recorded for audit)
+   * - `target_project_id`: optionally restricts sharing to a specific project
+   * - `new_visibility`: the visibility level to set; defaults to "shared"
+   */
+  shareMemory(
+    memory_id: string,
+    target_agent_id: string,
+    target_project_id?: string,
+    new_visibility: VisibilityLevel = "shared",
+    agent_id?: string,
+  ): { memory: MemoryNPC; provenance_id: string } {
+    const memory = this.memories[memory_id];
+    if (!memory) {
+      throw createNMError(
+        NM_ERRORS.MEMORY_NOT_FOUND,
+        `Memory not found: ${memory_id}`,
+        "List or search memories first, then retry with a valid memory ID.",
+      );
+    }
+
+    if (!VALID_VISIBILITY_LEVELS.includes(new_visibility)) {
+      throw createNMError(
+        NM_ERRORS.INPUT_VALIDATION_FAILED,
+        `Invalid visibility level: ${new_visibility}`,
+        `Use one of: ${VALID_VISIBILITY_LEVELS.join(", ")}.`,
+      );
+    }
+
+    const normalizedTargetAgent = normalizeOptionalAgentId(target_agent_id, "target_agent_id");
+    if (!normalizedTargetAgent) {
+      throw createNMError(
+        NM_ERRORS.INPUT_VALIDATION_FAILED,
+        "target_agent_id must be a non-empty string.",
+        "Provide the agent identifier to share with.",
+      );
+    }
+
+    if (target_project_id !== undefined) {
+      validateProjectId(target_project_id, "target_project_id");
+    }
+
+    const storedAgentId = resolveStoredAgentId(agent_id);
+    const now = new Date();
+
+    // Update visibility on the source memory
+    const previousVisibility = memory.visibility ?? "private";
+    const visibilityUpdates: MemoryUpdatePayload = { visibility: new_visibility };
+    this.appendWalEntry("update", { memory_id, updates: visibilityUpdates });
+    this.applyMemoryUpdates(memory_id, visibilityUpdates);
+
+    // Create a provenance trail memory in vigilant_monitoring
+    const provenanceId = `memory_${this.nextMemoryId++}`;
+    const provenanceContent = `Share provenance: memory ${memory_id} shared by agent ${storedAgentId} with agent ${normalizedTargetAgent}${target_project_id ? ` in project ${target_project_id}` : ""}. Visibility changed from ${previousVisibility} to ${new_visibility}.`;
+    const provenanceMemory: MemoryNPC = {
+      id: provenanceId,
+      name: `Share provenance ${memory_id}`,
+      archetype: "guard",
+      agent_id: storedAgentId,
+      project_id: normalizeProjectId(target_project_id ?? memory.project_id),
+      district: "vigilant_monitoring",
+      content: provenanceContent,
+      traits: ["vigilant", "protective"],
+      concerns: ["safety", "boundaries"],
+      connections: [memory_id],
+      tags: [
+        "topic:visibility",
+        "kind:provenance",
+        "scope:project",
+        "layer:implementation",
+        `share:from:${storedAgentId}`,
+        `share:to:${normalizedTargetAgent}`,
+      ],
+      created: now,
+      last_accessed: now,
+      access_count: 1,
+      intensity: 0.5,
+    };
+
+    // Append WAL before in-memory mutation
+    this.ensureCapacityForInsert();
+    this.appendWalEntry("store", { memory: this.serializeMemory(provenanceMemory) });
+    // Also link source memory to provenance
+    const updatedConnections = [...memory.connections, provenanceId];
+    this.appendWalEntry("update", { memory_id, updates: { connections: updatedConnections } as unknown as MemoryUpdatePayload });
+
+    this.insertMemory(provenanceMemory);
+    memory.connections = updatedConnections;
+    this.scheduleSave();
+
+    logger.info(
+      {
+        operation: "share_memory",
+        memory_id,
+        provenance_id: provenanceId,
+        from_agent: storedAgentId,
+        to_agent: normalizedTargetAgent,
+        new_visibility,
+        previous_visibility: previousVisibility,
+      },
+      "Shared memory",
+    );
+
+    return { memory: this.memories[memory_id], provenance_id: provenanceId };
   }
 
   /**
@@ -4816,6 +4950,11 @@ function buildRegisteredToolDescriptors(): ToolDescriptor[] {
             why_now: {
               type: "string",
               description: "Optional reason this task is being prioritized now"
+            },
+            visibility: {
+              type: "string",
+              enum: ["private", "shared", "global"],
+              description: "Optional visibility level: private (default, agent-local), shared (explicit share recipients), global (all agents)"
             }
           },
           required: ["content", "district"]
@@ -4918,6 +5057,11 @@ function buildRegisteredToolDescriptors(): ToolDescriptor[] {
             why_now: {
               type: ["string", "null"],
               description: "New prioritization reason (optional); pass null to clear"
+            },
+            visibility: {
+              type: ["string", "null"],
+              enum: ["private", "shared", "global", null],
+              description: "New visibility level (optional); pass null to clear (reverts to private default)"
             }
           },
           required: ["memory_id"]
@@ -5048,6 +5192,11 @@ function buildRegisteredToolDescriptors(): ToolDescriptor[] {
             session_id: {
               type: "string",
               description: "Optional session_id filter"
+            },
+            visibility: {
+              type: "array",
+              items: { type: "string", enum: ["private", "shared", "global"] },
+              description: "Optional visibility filter (OR logic). Unset memories are treated as private."
             }
           },
           required: ["query"]
@@ -5144,6 +5293,11 @@ function buildRegisteredToolDescriptors(): ToolDescriptor[] {
               type: "array",
               items: { type: "string", enum: ["draft", "validated", "outdated", "unset"] },
               description: "Optional epistemic status filters"
+            },
+            visibility: {
+              type: "array",
+              items: { type: "string", enum: ["private", "shared", "global"] },
+              description: "Optional visibility filter (OR logic). Unset memories are treated as private."
             }
           }
         }
@@ -5322,6 +5476,37 @@ function buildRegisteredToolDescriptors(): ToolDescriptor[] {
         }
       },
       {
+        name: "share_memory",
+        description: "Set a memory's visibility to 'shared' (or another level) and record an auditable provenance trail. Returns the updated memory and the provenance record ID.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            memory_id: {
+              type: "string",
+              description: "ID of the memory to share"
+            },
+            target_agent_id: {
+              type: "string",
+              description: "Agent identifier this memory is being shared with"
+            },
+            target_project_id: {
+              type: "string",
+              description: "Optional project identifier this memory is being shared into"
+            },
+            new_visibility: {
+              type: "string",
+              enum: ["private", "shared", "global"],
+              description: "Visibility level to set (default: shared)"
+            },
+            agent_id: {
+              type: "string",
+              description: "Optional agent performing the share action (uses stored default if omitted)"
+            }
+          },
+          required: ["memory_id", "target_agent_id"]
+        }
+      },
+      {
         name: "kanban_view",
         description: "Show a kanban board view of practical_execution memories, grouped by status (in_progress, blocked, ready, backlog, done). Useful for workflow status checks and WIP monitoring.",
         inputSchema: {
@@ -5486,7 +5671,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return buildListToolsResult();
     }
     case "store_memory": {
-      const { content, district, tags = [], emotional_valence, intensity = 0.5, agent_id, project_id, epistemic_status, session_id, status, current_slice, why_now } = request.params.arguments as any;
+      const { content, district, tags = [], emotional_valence, intensity = 0.5, agent_id, project_id, epistemic_status, session_id, status, current_slice, why_now, visibility } = request.params.arguments as any;
 
       try {
         if (status === null || current_slice === null || why_now === null) {
@@ -5539,6 +5724,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               status,
               current_slice,
               why_now,
+              visibility,
             );
           },
         );
@@ -5557,7 +5743,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return {
           content: [{
             type: "text",
-            text: `🧠 Stored memory "${memory.name}" in ${memorySystem.getAllDistricts().find(d => d.name.toLowerCase().replace(/\s+/g, '_') === district)?.name || district}\nID: ${memory.id}\nArchetype: ${memory.archetype}\nAgent: ${memory.agent_id ?? "unassigned"}\nProject: ${memory.project_id ?? "unset"}\nSession: ${memory.session_id ?? "unset"}\nStatus: ${memory.status ?? "unset"}\nEpistemic status: ${memory.epistemic_status ?? "unset"}\n${repeatLines}${warningLine}${repeatWarningLine}${cooldownLine}`
+            text: `🧠 Stored memory "${memory.name}" in ${memorySystem.getAllDistricts().find(d => d.name.toLowerCase().replace(/\s+/g, '_') === district)?.name || district}\nID: ${memory.id}\nArchetype: ${memory.archetype}\nAgent: ${memory.agent_id ?? "unassigned"}\nProject: ${memory.project_id ?? "unset"}\nSession: ${memory.session_id ?? "unset"}\nStatus: ${memory.status ?? "unset"}\nEpistemic status: ${memory.epistemic_status ?? "unset"}\nVisibility: ${memory.visibility ?? "private"}\n${repeatLines}${warningLine}${repeatWarningLine}${cooldownLine}`
           }]
         };
       } catch (error) {
@@ -5599,13 +5785,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       return {
         content: [{
           type: "text",
-          text: `🧠 Retrieved memory "${memory.name}"\nDistrict: ${memory.district}\nAgent: ${memory.agent_id ?? 'unassigned'}\nProject: ${memory.project_id ?? 'unset'}\nEpistemic status: ${memory.epistemic_status ?? 'unset'}\nContent: ${memory.content}\nTags: ${memory.tags.join(', ')}\nEmotional valence: ${memory.emotional_valence ?? 'unset'}\nIntensity: ${memory.intensity ?? 'unset'}\nAccess count: ${memory.access_count}${retrieval?.distill_suggestion ? `\n${retrieval.distill_suggestion}` : ''}`
+          text: `🧠 Retrieved memory "${memory.name}"\nDistrict: ${memory.district}\nAgent: ${memory.agent_id ?? 'unassigned'}\nProject: ${memory.project_id ?? 'unset'}\nEpistemic status: ${memory.epistemic_status ?? 'unset'}\nVisibility: ${memory.visibility ?? 'private'}\nContent: ${memory.content}\nTags: ${memory.tags.join(', ')}\nEmotional valence: ${memory.emotional_valence ?? 'unset'}\nIntensity: ${memory.intensity ?? 'unset'}\nAccess count: ${memory.access_count}${retrieval?.distill_suggestion ? `\n${retrieval.distill_suggestion}` : ''}`
         }]
       };
     }
 
     case "update_memory": {
-      const { memory_id, content, district, tags, emotional_valence, intensity, epistemic_status, project_id, session_id, actor_district, agent_id, memory_agent_id, status, current_slice, why_now } = request.params.arguments as any;
+      const { memory_id, content, district, tags, emotional_valence, intensity, epistemic_status, project_id, session_id, actor_district, agent_id, memory_agent_id, status, current_slice, why_now, visibility } = request.params.arguments as any;
       try {
         if (status !== undefined && status !== null) validateKanbanStatus(status);
         const normalizedActorAgentId = normalizeOptionalAgentId(agent_id);
@@ -5622,6 +5808,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (status !== undefined) updates.status = status;
         if (current_slice !== undefined) updates.current_slice = current_slice;
         if (why_now !== undefined) updates.why_now = why_now;
+        if (visibility !== undefined) updates.visibility = visibility;
 
         const updateResult = await runMutatingTool(
           "update_memory",
@@ -5634,7 +5821,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return {
           content: [{
             type: "text",
-            text: `✏️ Updated memory "${memory.name}" (${memory_id})\nDistrict: ${memory.district}\nAgent: ${memory.agent_id ?? DEFAULT_AGENT_ID}\nProject: ${memory.project_id ?? 'unset'}\nSession: ${memory.session_id ?? 'unset'}\nStatus: ${memory.status ?? 'unset'}\nEpistemic status: ${memory.epistemic_status ?? 'unset'}\nTags: ${memory.tags.join(', ')}${cooldownLine}`
+            text: `✏️ Updated memory "${memory.name}" (${memory_id})\nDistrict: ${memory.district}\nAgent: ${memory.agent_id ?? DEFAULT_AGENT_ID}\nProject: ${memory.project_id ?? 'unset'}\nSession: ${memory.session_id ?? 'unset'}\nStatus: ${memory.status ?? 'unset'}\nEpistemic status: ${memory.epistemic_status ?? 'unset'}\nVisibility: ${memory.visibility ?? 'private'}\nTags: ${memory.tags.join(', ')}${cooldownLine}`
           }]
         };
       } catch (error) {
@@ -5709,7 +5896,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         emotional_valence_min, emotional_valence_max,
         intensity_min, intensity_max,
         min_intensity, max_intensity,
-        session_id,
+        session_id, visibility,
       } = request.params.arguments as any;
       try {
         if (project_id !== undefined) {
@@ -5727,7 +5914,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           min_score,
           emotional_valence_min, emotional_valence_max,
           resolvedIntensityMin, resolvedIntensityMax,
-          context, recency_weight, session_id,
+          context, recency_weight, session_id, visibility,
         );
         const results = searchResult.results;
         const didYouMeanLine = searchResult.did_you_mean
@@ -5828,7 +6015,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     }
 
     case "list_memories": {
-      const { page = 1, page_size = 20, district, archetype, project_id, epistemic_statuses, session_id } = request.params.arguments as any;
+      const { page = 1, page_size = 20, district, archetype, project_id, epistemic_statuses, session_id, visibility } = request.params.arguments as any;
       try {
         if (project_id !== undefined) {
           validateProjectId(project_id);
@@ -5836,7 +6023,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (session_id !== undefined) {
           validateSessionId(session_id);
         }
-        const result = memorySystem.listMemories(page, page_size, district, archetype, project_id, epistemic_statuses, session_id);
+        const result = memorySystem.listMemories(page, page_size, district, archetype, project_id, epistemic_statuses, session_id, visibility);
         if (result.memories.length === 0) {
           return { content: [{ type: "text", text: `📋 No memories found (page ${page})` }] };
         }
@@ -5954,6 +6141,33 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             MCP_INTERNAL_ERROR_CODE,
             "Unable to list sessions.",
             "Retry list_sessions; if the problem persists, inspect server and storage health.",
+          ),
+        );
+      }
+    }
+
+    case "share_memory": {
+      const { memory_id, target_agent_id, target_project_id, new_visibility, agent_id } = request.params.arguments as any;
+      try {
+        const result = await runMutatingTool(
+          "share_memory",
+          () => memorySystem.shareMemory(memory_id, target_agent_id, target_project_id, new_visibility, agent_id),
+        );
+        return {
+          content: [{
+            type: "text",
+            text: `🔗 Shared memory "${result.memory.name}" (${memory_id})\nVisibility: ${result.memory.visibility ?? "shared"}\nProvenance record: ${result.provenance_id}\nShared with: ${target_agent_id}${target_project_id ? `\nProject: ${target_project_id}` : ""}`
+          }]
+        };
+      } catch (error) {
+        return toolErrorResult(
+          "share_memory",
+          "Failed to share memory",
+          error,
+          formatMcpError(
+            NM_ERRORS.INPUT_VALIDATION_FAILED,
+            "Share memory request was invalid.",
+            "Verify the memory_id and target_agent_id, then retry share_memory.",
           ),
         );
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3888,12 +3888,11 @@ class NeurodivergentMemory {
     // Append WAL before in-memory mutation
     this.ensureCapacityForInsert();
     this.appendWalEntry("store", { memory: this.serializeMemory(provenanceMemory) });
-    // Also link source memory to provenance
-    const updatedConnections = [...memory.connections, provenanceId];
-    this.appendWalEntry("update", { memory_id, updates: { connections: updatedConnections } as unknown as MemoryUpdatePayload });
+    // Use WAL "connect" operation so replay via connectMemoriesInternal restores the link
+    this.appendWalEntry("connect", { memory_id_1: memory_id, memory_id_2: provenanceId, bidirectional: true });
 
     this.insertMemory(provenanceMemory);
-    memory.connections = updatedConnections;
+    this.connectMemoriesInternal(memory_id, provenanceId, true);
     this.scheduleSave();
 
     logger.info(
@@ -5808,7 +5807,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (status !== undefined) updates.status = status;
         if (current_slice !== undefined) updates.current_slice = current_slice;
         if (why_now !== undefined) updates.why_now = why_now;
-        if (visibility !== undefined) updates.visibility = visibility;
+        if (visibility !== undefined) {
+          if (visibility !== null && !VALID_VISIBILITY_LEVELS.includes(visibility)) {
+            throw createNMError(
+              NM_ERRORS.INPUT_VALIDATION_FAILED,
+              `Invalid visibility level: ${visibility}`,
+              `Use one of: ${VALID_VISIBILITY_LEVELS.join(", ")}, or null to clear.`,
+            );
+          }
+          updates.visibility = visibility as VisibilityLevel | null;
+        }
 
         const updateResult = await runMutatingTool(
           "update_memory",
@@ -6156,7 +6164,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return {
           content: [{
             type: "text",
-            text: `🔗 Shared memory "${result.memory.name}" (${memory_id})\nVisibility: ${result.memory.visibility ?? "shared"}\nProvenance record: ${result.provenance_id}\nShared with: ${target_agent_id}${target_project_id ? `\nProject: ${target_project_id}` : ""}`
+            text: `🔗 Shared memory "${result.memory.name}" (${memory_id})\nVisibility: ${result.memory.visibility ?? (new_visibility ?? "shared")}\nProvenance record: ${result.provenance_id}\nShared with: ${target_agent_id}${target_project_id ? `\nProject: ${target_project_id}` : ""}`
           }]
         };
       } catch (error) {

--- a/test/visibility.test.mjs
+++ b/test/visibility.test.mjs
@@ -98,7 +98,7 @@ test("store_memory with visibility:private stores and shows Visibility: private"
     assert.match(resultText(stored), /Visibility: private/);
 
     const retrieved = await server.callTool(2, "retrieve_memory", { memory_id: "memory_1" });
-    assert.match(resultText(retrieved), /private/);
+    assert.match(resultText(retrieved), /Visibility: private/);
   } finally {
     server.stop();
   }
@@ -337,7 +337,7 @@ test("share_memory sets visibility to shared and creates a provenance record", a
 
     // Source memory should now be shared
     const retrieved = await server.callTool(3, "retrieve_memory", { memory_id: "memory_1" });
-    assert.match(resultText(retrieved), /shared/);
+    assert.match(resultText(retrieved), /Visibility: shared/);
   } finally {
     server.stop();
   }

--- a/test/visibility.test.mjs
+++ b/test/visibility.test.mjs
@@ -1,0 +1,401 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+function startServer(options = {}) {
+  const tempDir = options.tempDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "ndm-visibility-test-"));
+
+  fs.mkdirSync(tempDir, { recursive: true });
+
+  const child = spawn(process.execPath, ["build/index.js"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      NEURODIVERGENT_MEMORY_DIR: tempDir,
+      NEURODIVERGENT_MEMORY_LOG_LEVEL: "error",
+      ...(options.env ?? {}),
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  child.stdout.setEncoding("utf8");
+  let buffer = "";
+  const pending = new Map();
+
+  child.stdout.on("data", chunk => {
+    buffer += chunk;
+    let newline = buffer.indexOf("\n");
+    while (newline >= 0) {
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      newline = buffer.indexOf("\n");
+      if (!line) continue;
+      let parsed;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (parsed.id !== undefined && pending.has(parsed.id)) {
+        const resolver = pending.get(parsed.id);
+        pending.delete(parsed.id);
+        resolver(parsed);
+      }
+    }
+  });
+
+  function callTool(id, name, args) {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`Timed out waiting for response to request ${id}`));
+      }, 15000);
+
+      pending.set(id, response => {
+        clearTimeout(timeout);
+        resolve(response);
+      });
+
+      child.stdin.write(`${JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method: "tools/call",
+        params: { name, arguments: args },
+      })}\n`);
+    });
+  }
+
+  function stop() {
+    child.kill();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+
+  return { callTool, stop };
+}
+
+function resultText(response) {
+  return response.result?.content?.[0]?.text ?? "";
+}
+
+function hasResult(response, memoryId) {
+  return resultText(response).includes(memoryId);
+}
+
+// ── store_memory ─────────────────────────────────────────────────────────────
+
+test("store_memory with visibility:private stores and shows Visibility: private", async () => {
+  const server = startServer();
+  try {
+    const stored = await server.callTool(1, "store_memory", {
+      content: "Private research note",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+      visibility: "private",
+    });
+    assert.match(resultText(stored), /Visibility: private/);
+
+    const retrieved = await server.callTool(2, "retrieve_memory", { memory_id: "memory_1" });
+    assert.match(resultText(retrieved), /private/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("store_memory with visibility:shared stores and shows Visibility: shared", async () => {
+  const server = startServer();
+  try {
+    const stored = await server.callTool(1, "store_memory", {
+      content: "Shared planning note",
+      district: "practical_execution",
+      tags: ["topic:test", "scope:session", "kind:task", "layer:implementation"],
+      visibility: "shared",
+    });
+    assert.match(resultText(stored), /Visibility: shared/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("store_memory with visibility:global stores and shows Visibility: global", async () => {
+  const server = startServer();
+  try {
+    const stored = await server.callTool(1, "store_memory", {
+      content: "Global reference memory",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:global", "kind:reference", "layer:architecture"],
+      visibility: "global",
+    });
+    assert.match(resultText(stored), /Visibility: global/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("store_memory without visibility shows Visibility: private as default", async () => {
+  const server = startServer();
+  try {
+    const stored = await server.callTool(1, "store_memory", {
+      content: "Memory without explicit visibility",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+    });
+    assert.match(resultText(stored), /Visibility: private/);
+  } finally {
+    server.stop();
+  }
+});
+
+// ── update_memory ─────────────────────────────────────────────────────────────
+
+test("update_memory can change visibility from private to shared", async () => {
+  const server = startServer();
+  try {
+    await server.callTool(1, "store_memory", {
+      content: "Initially private memory",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+    });
+
+    const updated = await server.callTool(2, "update_memory", {
+      memory_id: "memory_1",
+      visibility: "shared",
+    });
+    assert.match(resultText(updated), /Visibility: shared/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("update_memory with visibility:null clears visibility (reverts to private default)", async () => {
+  const server = startServer();
+  try {
+    await server.callTool(1, "store_memory", {
+      content: "Shared memory to be cleared",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+      visibility: "shared",
+    });
+
+    const updated = await server.callTool(2, "update_memory", {
+      memory_id: "memory_1",
+      visibility: null,
+    });
+    assert.match(resultText(updated), /Visibility: private/);
+  } finally {
+    server.stop();
+  }
+});
+
+// ── search_memories ───────────────────────────────────────────────────────────
+
+test("search_memories with visibility filter returns only matching memories", async () => {
+  const server = startServer();
+  try {
+    await server.callTool(1, "store_memory", {
+      content: "Private research finding alpha",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+      visibility: "private",
+    });
+
+    await server.callTool(2, "store_memory", {
+      content: "Shared research finding alpha",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+      visibility: "shared",
+    });
+
+    const sharedOnly = await server.callTool(3, "search_memories", {
+      query: "research finding alpha",
+      visibility: ["shared"],
+    });
+
+    assert.equal(hasResult(sharedOnly, "memory_1"), false, "private memory should be excluded");
+    assert.equal(hasResult(sharedOnly, "memory_2"), true, "shared memory should be included");
+  } finally {
+    server.stop();
+  }
+});
+
+test("search_memories with no visibility filter returns all memories", async () => {
+  const server = startServer();
+  try {
+    await server.callTool(1, "store_memory", {
+      content: "Private beta note",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+      visibility: "private",
+    });
+
+    await server.callTool(2, "store_memory", {
+      content: "Global beta note",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+      visibility: "global",
+    });
+
+    const all = await server.callTool(3, "search_memories", { query: "beta note" });
+    assert.equal(hasResult(all, "memory_1"), true);
+    assert.equal(hasResult(all, "memory_2"), true);
+  } finally {
+    server.stop();
+  }
+});
+
+// ── list_memories ─────────────────────────────────────────────────────────────
+
+test("list_memories with visibility filter returns only matching memories", async () => {
+  const server = startServer();
+  try {
+    await server.callTool(1, "store_memory", {
+      content: "Private task gamma",
+      district: "practical_execution",
+      tags: ["topic:test", "scope:session", "kind:task", "layer:implementation"],
+      visibility: "private",
+    });
+
+    await server.callTool(2, "store_memory", {
+      content: "Global task gamma",
+      district: "practical_execution",
+      tags: ["topic:test", "scope:session", "kind:task", "layer:implementation"],
+      visibility: "global",
+    });
+
+    const globalOnly = await server.callTool(3, "list_memories", {
+      visibility: ["global"],
+      page_size: 20,
+    });
+
+    assert.equal(hasResult(globalOnly, "memory_1"), false, "private memory should be excluded");
+    assert.equal(hasResult(globalOnly, "memory_2"), true, "global memory should be included");
+  } finally {
+    server.stop();
+  }
+});
+
+test("list_memories with multi-value visibility filter uses OR logic", async () => {
+  const server = startServer();
+  try {
+    await server.callTool(1, "store_memory", {
+      content: "Private delta note",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+      visibility: "private",
+    });
+
+    await server.callTool(2, "store_memory", {
+      content: "Shared delta note",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+      visibility: "shared",
+    });
+
+    await server.callTool(3, "store_memory", {
+      content: "Global delta note",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+      visibility: "global",
+    });
+
+    const sharedOrGlobal = await server.callTool(4, "list_memories", {
+      visibility: ["shared", "global"],
+      page_size: 20,
+    });
+
+    assert.equal(hasResult(sharedOrGlobal, "memory_1"), false, "private should be excluded");
+    assert.equal(hasResult(sharedOrGlobal, "memory_2"), true, "shared should be included");
+    assert.equal(hasResult(sharedOrGlobal, "memory_3"), true, "global should be included");
+  } finally {
+    server.stop();
+  }
+});
+
+// ── share_memory ──────────────────────────────────────────────────────────────
+
+test("share_memory sets visibility to shared and creates a provenance record", async () => {
+  const server = startServer();
+  try {
+    await server.callTool(1, "store_memory", {
+      content: "Private finding to share",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:note", "layer:research"],
+    });
+
+    const shared = await server.callTool(2, "share_memory", {
+      memory_id: "memory_1",
+      target_agent_id: "agent_bob",
+    });
+
+    const text = resultText(shared);
+    assert.match(text, /Shared memory/);
+    assert.match(text, /Visibility: shared/);
+    assert.match(text, /Provenance record: memory_2/);
+    assert.match(text, /Shared with: agent_bob/);
+
+    // Source memory should now be shared
+    const retrieved = await server.callTool(3, "retrieve_memory", { memory_id: "memory_1" });
+    assert.match(resultText(retrieved), /shared/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("share_memory with new_visibility:global sets visibility to global", async () => {
+  const server = startServer();
+  try {
+    await server.callTool(1, "store_memory", {
+      content: "Private org-wide reference",
+      district: "logical_analysis",
+      tags: ["topic:test", "scope:session", "kind:reference", "layer:architecture"],
+    });
+
+    const shared = await server.callTool(2, "share_memory", {
+      memory_id: "memory_1",
+      target_agent_id: "agent_org",
+      new_visibility: "global",
+    });
+
+    assert.match(resultText(shared), /Visibility: global/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("share_memory with target_project_id records project in output", async () => {
+  const server = startServer();
+  try {
+    await server.callTool(1, "store_memory", {
+      content: "Cross-project insight",
+      district: "creative_synthesis",
+      tags: ["topic:test", "scope:project", "kind:insight", "layer:architecture"],
+    });
+
+    const shared = await server.callTool(2, "share_memory", {
+      memory_id: "memory_1",
+      target_agent_id: "agent_carol",
+      target_project_id: "proj_gamma",
+    });
+
+    const text = resultText(shared);
+    assert.match(text, /Project: proj_gamma/);
+  } finally {
+    server.stop();
+  }
+});
+
+test("share_memory on non-existent memory_id returns error", async () => {
+  const server = startServer();
+  try {
+    const result = await server.callTool(1, "share_memory", {
+      memory_id: "memory_9999",
+      target_agent_id: "agent_x",
+    });
+    const text = resultText(result);
+    assert.match(text, /error|not found|Error|invalid/i);
+  } finally {
+    server.stop();
+  }
+});


### PR DESCRIPTION
## Summary

Closes #113 — implements the visibility model and share flow for v0.4.0.

## What changed

### New type
- `VisibilityLevel = "private" | "shared" | "global"` added to `src/core/types.ts`
- `visibility?: VisibilityLevel` field added to `MemoryNPC` interface

### Core methods
- **`storeMemory()`** — accepts optional `visibility` param; stored on memory object
- **`applyMemoryUpdates()`** — handles `visibility: null` (clears field, reverts to private default) and `visibility: <level>` (sets field)
- **`searchMemories()`** — accepts optional `visibility?: VisibilityLevel[]` filter (OR logic, same pattern as tags)
- **`listMemories()`** — same visibility array filter
- **`shareMemory()`** (new) — sets visibility on target memory, creates an auditable provenance trail memory in `vigilant_monitoring` with bidirectional connection back to source

### Tool layer
| Tool | Change |
|---|---|
| `store_memory` | `visibility` input field; output shows `Visibility:` line |
| `update_memory` | `visibility` input field (nullable); output shows `Visibility:` line |
| `search_memories` | `visibility` array filter input |
| `list_memories` | `visibility` array filter input |
| `retrieve_memory` | output now shows `Visibility:` line |
| `share_memory` | **new tool** — sets visibility + records provenance |

### Tests
`test/visibility.test.mjs` — 14 integration tests covering:
- `store_memory` with all three visibility levels + default
- `update_memory` visibility set and null-clear
- `search_memories` filtered and unfiltered
- `list_memories` single and multi-value OR filter
- `share_memory` full flow, global override, project scoping, and invalid-ID error path

## Backward compatibility

No migration required. Existing memories without a `visibility` field are treated as `"private"` by all filter paths at read time — default-private by design.

## Test results

```
✔ 14/14 tests pass
```

Build: `tsc` exits 0.