### PR TITLE
docs: README — add MCP-first clarification (issue #134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ npm -v # Should print an npm 11.x version.
 npx neurodivergent-memory@latest init-agent-kit
 ```
 
+> **MCP-first note:** This repository's MCP server (see `server.json` and the `neurodivergent-memory` npm package) is the canonical distribution and runtime for the memory server. Marketplace artifacts and editor extensions (VS Code, Azure DevOps, Visual Studio) are optional convenience integrations that wrap or package the core server; prefer the `npx neurodivergent-memory` or Docker examples below for predictable installation and versioning.
+
 ### Linux/macOS
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -358,7 +358,9 @@ the snapshot file and will warn if it detects an open WAL for the target directo
 
 ### Marketplace Distribution (Optional)
 
-Tagged releases can publish extension artifacts to three marketplace channels, plus Open VSX:
+Tagged releases can publish extension artifacts to three marketplace channels, plus Open VSX.
+
+> **Runtime note:** the canonical `neurodivergent-memory` runtime is the MCP server package and its Docker image, not the marketplace artifacts. Marketplace/extension channels are optional distribution wrappers for editor and CI integration, not replacements for the underlying runtime.
 
 - Azure DevOps / Visual Studio Marketplace (Azure extension manifest: `vss-extension.json`)
 - VS Code Marketplace and Open VSX (VS Code extension manifest: `package.json`)

--- a/docs/marketplace-overview.md
+++ b/docs/marketplace-overview.md
@@ -16,6 +16,8 @@ Use this package with MCP-capable clients and agents that need long-lived contex
 The repository also ships a thin VS Code companion extension that helps users configure the MCP server quickly.
 The extension does not replace the MCP runtime; it provides setup-oriented commands and marketplace discoverability.
 
+> **MCP-first note:** The `neurodivergent-memory` runtime is the canonical distribution. Use the npm package or Docker image directly, and only use the VS Code extension as a convenience layer for configuration or discovery.
+
 Quick start:
 
 ```bash


### PR DESCRIPTION
Small README clarification to emphasize MCP-first installation and that marketplace/editor extensions are optional integrations. Links to issue: https://github.com/jmeyer1980/neurodivergent-memory/issues/134