### PR TITLE
feat(rolodex): search by relevance, and create memories

### DIFF
--- a/docs/superpowers/plans/2026-08-02-rolodex-search-and-creation.md
+++ b/docs/superpowers/plans/2026-08-02-rolodex-search-and-creation.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** Vanilla ES modules, no build step for the web apps. `node --test` for unit tests (`npm test`), Playwright for browser tests (`npx playwright test`, projects `desktop-chrome` and `mobile-safari`).
 
+**Epic:** #162
+
 **Spec:** `docs/superpowers/specs/2026-08-02-rolodex-search-and-creation-design.md`
 
 ## Global Constraints
@@ -29,7 +31,7 @@ Creation is nearly self-contained: `POST /save` already exists and routes to `st
 
 ---
 
-### Task 1: Autofill resolver
+### Task 1 [#163]: Autofill resolver
 
 The pure function that decides what a new memory inherits from where you are standing.
 
@@ -147,7 +149,7 @@ git commit -m "feat(rolodex): resolve what a new memory inherits from context"
 
 ---
 
-### Task 2: Create mode on the edit modal
+### Task 2 [#164]: Create mode on the edit modal
 
 One modal, two modes. Not a second copy — the two apps' near-duplicate modals have already drifted once.
 
@@ -338,7 +340,7 @@ git commit -m "feat(rolodex): create memories, in one modal with two modes"
 
 ---
 
-### Task 3: Long-press to create in context
+### Task 3 [#165]: Long-press to create in context
 
 **Files:**
 - Modify: `scripts/nd-mem-rolodex-helpers.mjs` (`routeGesture`), `scripts/nd-mem-rolodex.html` (pointer handlers, CSS)
@@ -499,7 +501,7 @@ git commit -m "feat(rolodex): long-press a project or district to create in cont
 
 ---
 
-### Task 4: The result parser
+### Task 4 [#166]: The result parser
 
 The one fragile seam in the design, isolated into a pure function and pinned by a contract test in Task 5.
 
@@ -607,7 +609,7 @@ git commit -m "feat(rolodex): parse search hits out of the daemon's prose"
 
 ---
 
-### Task 5: The `/search` route and its contract test
+### Task 5 [#167]: The `/search` route and its contract test
 
 **Files:**
 - Modify: `scripts/nd-mem-bridge-server.mjs`
@@ -746,7 +748,7 @@ git commit -m "feat(bridge): serve BM25 search, pinned by a format contract test
 
 ---
 
-### Task 6: The lit predicate and lit-stepping
+### Task 6 [#168]: The lit predicate and lit-stepping
 
 **Files:**
 - Modify: `scripts/nd-mem-rolodex-helpers.mjs`
@@ -891,7 +893,7 @@ git commit -m "feat(rolodex): light a card when it or anything inside it matches
 
 ---
 
-### Task 7: Search in the page
+### Task 7 [#169]: Search in the page
 
 **Files:**
 - Modify: `scripts/nd-mem-rolodex.html` — markup, CSS, `state`, `updateChrome`, `updateFrontCard`/`buildDrum` render path, `stepBy`

--- a/docs/superpowers/plans/2026-08-02-rolodex-search-and-creation.md
+++ b/docs/superpowers/plans/2026-08-02-rolodex-search-and-creation.md
@@ -1,0 +1,1103 @@
+# Rolodex Search & Creation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the rolodex the two capabilities the classic app has and it lacks — finding memories by BM25 relevance, and creating them.
+
+**Architecture:** All new pure logic goes into `scripts/nd-mem-rolodex-helpers.mjs`, which is DOM-free and unit-tested under `node --test`. The bridge gains one read-only route that calls the daemon's `search_memories` and returns structured hits. The page gains a search input, a dim-rendering pass, a `+` control, a create mode on the existing edit modal, and a long-press gesture. Nothing changes in drum geometry or the nav tree.
+
+**Tech Stack:** Vanilla ES modules, no build step for the web apps. `node --test` for unit tests (`npm test`), Playwright for browser tests (`npx playwright test`, projects `desktop-chrome` and `mobile-safari`).
+
+**Spec:** `docs/superpowers/specs/2026-08-02-rolodex-search-and-creation-design.md`
+
+## Global Constraints
+
+- **Branch is `feat/rolodex-search-and-creation`**, based on the merged `development` (`fb13048`). PRs target `development`; the remote is `neurodivergent-memory`, never `origin`.
+- **`npm test` is `npm run build && node test-support/run-tests.mjs`** — `node --test` with DEFAULT discovery, which treats everything under `test/` as a test file. Shared test helpers live in `test-support/`, NOT `test/`. Browser specs stay in `e2e/`.
+- **Verified baseline before this work:** `npm test` → tests 294 / pass 292 / **fail 2**. Those 2 are pre-existing wording drift in `test/agent-customization-wording.test.mjs`, unrelated. `npx playwright test` → **51 passed / 1 skipped** (the skip is the desktop-only wheel guard; mobile WebKit has no wheel input). Your bar: the same 2 failures and no others, and zero NEW skips.
+- **Every new colour uses an existing CSS custom property** (`--text`, `--muted`, `--faint`, `--primary`, `--surface`, `--surfaceBorder`, `--wash`, `--washStrong`, `--cardBase`, `--cardWash`). No literal colours. Check both themes — light is a warm sepia tuned by measuring rendered pixels.
+- **Chromium cannot hit-test 3D-rotated cards.** Real controls live only on chrome or `.card3d.front`; anything on a side card resolves through the page's own `cardIndexAtPoint`.
+- **`flex-wrap` on `#chrome` is load-bearing at every width.** A phone in landscape is ~737–852px and misses the 560px query.
+- **The plan's prescribed code is not pre-verified.** The previous slice found six defects in its own plan — an algorithm that failed the plan's own assertion, an e2e test that never exercised the feature, a wrong geometry claim, a test that could not fail, a mid-animation timeout, and a two-task layout interaction. **Run every test you write and confirm it fails before you make it pass.** If the plan's code is wrong, fix it, keep the intent, and report the deviation with evidence.
+- Run `npm test` and `npx playwright test` **in the foreground** before each commit. Do not delegate verification to a background job.
+
+---
+
+# PHASE 1 — CREATION (Tasks 1–3)
+
+Creation is nearly self-contained: `POST /save` already exists and routes to `store_memory`. Phase 1 can ship even if Phase 2 needs another round.
+
+---
+
+### Task 1: Autofill resolver
+
+The pure function that decides what a new memory inherits from where you are standing.
+
+**Files:**
+- Modify: `scripts/nd-mem-rolodex-helpers.mjs` (append after `truncateNodeLabel`)
+- Test: `test/rolodex-helpers.test.mjs`
+
+**Interfaces:**
+- Consumes: `UNASSIGNED` (already exported from the same file).
+- Produces: `createDefaultsFor(view, pressedCard) => { projectId: string|null, district: string|null }`, exported. `view` is `state.view` (`{ level, projectId, districtId }`). `pressedCard` is `null` for the `+` button, or `{ kind: 'project'|'district', id: string }` for a long-press.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/rolodex-helpers.test.mjs`, adding `createDefaultsFor` to the import block at the top:
+
+```js
+test('createDefaultsFor inherits nothing at the projects level', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'projects', projectId: null, districtId: null }, null),
+    { projectId: null, district: null },
+  );
+});
+
+test('createDefaultsFor inherits the project at the districts level', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'districts', projectId: 'alpha', districtId: null }, null),
+    { projectId: 'alpha', district: null },
+  );
+});
+
+test('createDefaultsFor inherits project and district at the memories level', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'memories', projectId: 'alpha', districtId: 'logical_analysis' }, null),
+    { projectId: 'alpha', district: 'logical_analysis' },
+  );
+});
+
+test('createDefaultsFor takes a long-pressed project card over the current view', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'projects', projectId: null, districtId: null }, { kind: 'project', id: 'beta' }),
+    { projectId: 'beta', district: null },
+  );
+});
+
+test('createDefaultsFor takes a long-pressed district card with its parent project', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'districts', projectId: 'alpha', districtId: null }, { kind: 'district', id: 'vigilant_monitoring' }),
+    { projectId: 'alpha', district: 'vigilant_monitoring' },
+  );
+});
+
+test('createDefaultsFor never inherits the unassigned sentinel as a real project', () => {
+  // '(no project)' is a display bucket, not a project id -- storing it would
+  // create a literal project named after the placeholder.
+  assert.deepEqual(
+    createDefaultsFor({ level: 'districts', projectId: UNASSIGNED, districtId: null }, null),
+    { projectId: null, district: null },
+  );
+  assert.deepEqual(
+    createDefaultsFor({ level: 'projects', projectId: null, districtId: null }, { kind: 'project', id: UNASSIGNED }),
+    { projectId: null, district: null },
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/rolodex-helpers.test.mjs`
+Expected: FAIL — `SyntaxError: The requested module ... does not provide an export named 'createDefaultsFor'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/nd-mem-rolodex-helpers.mjs`:
+
+```js
+// What a new memory inherits from where you are standing. The deeper you are,
+// the more context it takes -- which is exactly what the coordinate already
+// means. A long-pressed card outranks the current view, because pressing a
+// specific card is a more explicit statement of intent than standing near it.
+//
+// UNASSIGNED is a DISPLAY bucket for memories with no project, not a project
+// id. Inheriting it would create a real project literally named '(no project)'.
+export function createDefaultsFor(view, pressedCard = null) {
+  const realProject = (id) => (id && id !== UNASSIGNED ? String(id) : null);
+
+  if (pressedCard && pressedCard.kind === 'project') {
+    return { projectId: realProject(pressedCard.id), district: null };
+  }
+  if (pressedCard && pressedCard.kind === 'district') {
+    return { projectId: realProject(view.projectId), district: String(pressedCard.id) };
+  }
+  if (view.level === 'memories') {
+    return { projectId: realProject(view.projectId), district: view.districtId ? String(view.districtId) : null };
+  }
+  if (view.level === 'districts') {
+    return { projectId: realProject(view.projectId), district: null };
+  }
+  return { projectId: null, district: null };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/rolodex-helpers.test.mjs`
+Expected: PASS, whole file green.
+
+- [ ] **Step 5: Run the full suite and commit**
+
+Run: `npm test` — expect the 2 known `agent-customization-wording` failures and no others.
+
+```bash
+git add scripts/nd-mem-rolodex-helpers.mjs test/rolodex-helpers.test.mjs
+git commit -m "feat(rolodex): resolve what a new memory inherits from context"
+```
+
+---
+
+### Task 2: Create mode on the edit modal
+
+One modal, two modes. Not a second copy — the two apps' near-duplicate modals have already drifted once.
+
+**Files:**
+- Modify: `scripts/nd-mem-rolodex.html` — modal markup (~`:367-381`), `openEditModal` (~`:1627`), `submitEdit` (~`:1645`), the `els` map, listener wiring
+- Test: `e2e/rolodex-layout.spec.ts`
+
+**Interfaces:**
+- Consumes: `H.createDefaultsFor(view, pressedCard)` from Task 1; the existing `POST /save` route, which accepts `{ content, district, tags, intensity, projectId, visibility, epistemicStatus, ... }` and maps them to `store_memory`.
+- Produces: `openCreateModal(pressedCard = null)`, and `state.modalMode` which is `'edit'` or `'create'`. Task 3 calls `openCreateModal`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `e2e/rolodex-layout.spec.ts`:
+
+```ts
+// The rolodex could read, navigate, rename and edit -- but not create. The
+// classic app has had a New Card form all along.
+test('the + button opens a create modal pre-filled from where you are standing', async ({ page }) => {
+  test.slow();
+  // At the wall: nothing inherited.
+  await page.locator('#createBtn').click();
+  await expect(page.locator('#editModalBg')).toHaveClass(/open/);
+  expect(await page.locator('#editModalTitle').textContent()).toMatch(/new memory/i);
+  expect(await page.locator('#editProject').inputValue()).toBe('');
+  await page.locator('#editCancelBtn').click();
+
+  // At memories depth: project AND district inherited.
+  expect(await diveToMemories(page)).toBe('memories');
+  const where = await page.evaluate(() => {
+    const segs = [...document.querySelectorAll('#crumb .seg')];
+    return { project: (segs[1]?.getAttribute('title') ?? segs[1]?.textContent ?? '').trim(),
+             district: (segs[2]?.getAttribute('title') ?? segs[2]?.textContent ?? '').trim() };
+  });
+  await page.locator('#createBtn').click();
+  await expect(page.locator('#editModalBg')).toHaveClass(/open/);
+  expect(await page.locator('#editProject').inputValue()).toBe(where.project);
+  expect(await page.locator('#editDistrict').inputValue()).toBe(where.district);
+  await page.locator('#editCancelBtn').click();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx playwright test -g "the \+ button opens a create modal"`
+Expected: FAIL — locator `#createBtn` resolves to nothing.
+
+- [ ] **Step 3: Add the button and give the modal an addressable title**
+
+In `scripts/nd-mem-rolodex.html`, add to the chrome bar's right-hand cluster, immediately before `#helpBtn`:
+
+```html
+      <button class="pill" id="createBtn" title="New memory" aria-label="New memory">+</button>
+```
+
+Give the modal heading an id so both modes can address it — change `<h2>Edit memory</h2>` in `#editModalBg` to:
+
+```html
+      <h2 id="editModalTitle">Edit memory</h2>
+```
+
+- [ ] **Step 4: Add create mode**
+
+Add `createBtn: $('#createBtn')` to the `els` object. Then add beside `openEditModal`:
+
+```js
+    // One modal, two modes. A second modal would drift from this one exactly as
+    // the classic app's copy already drifted from it -- that divergence was a
+    // code-review finding, not a hypothetical.
+    function openCreateModal(pressedCard = null){
+      const defaults = H.createDefaultsFor(state.view, pressedCard);
+      state.modalMode = 'create';
+      state.editingId = null;
+      $('#editModalTitle').textContent = 'New memory';
+      $('#editSaveBtn').textContent = 'Create';
+      const districts = H.CANONICAL_DISTRICTS;
+      $('#editDistrict').innerHTML = districts.map(d => `<option value="${esc(d)}">${esc(d)}</option>`).join('');
+      $('#editContent').value = '';
+      $('#editDistrict').value = defaults.district || 'practical_execution';
+      // Seeded the same way openEditModal does, so submitEdit's "only send a
+      // district the user actually chose" guard behaves identically in both modes.
+      state.editingDistrict = $('#editDistrict').value;
+      $('#editProject').value = defaults.projectId ?? '';
+      $('#editVisibility').value = 'private';
+      $('#editIntensity').value = '0.5';
+      $('#editEpistemic').value = '';
+      $('#editTags').value = '';
+      $('#editModalBg').classList.add('open');
+      $('#editContent').focus();
+    }
+```
+
+In `openEditModal`, set the mode and restore the labels — add immediately after `state.editingId = m.id;`:
+
+```js
+      state.modalMode = 'edit';
+      $('#editModalTitle').textContent = 'Edit memory';
+      $('#editSaveBtn').textContent = 'Save changes';
+```
+
+- [ ] **Step 5: Branch the submit**
+
+Do NOT try to surgically edit the object literal — replace the whole head of
+`submitEdit` down to and including the district guard. Read the current function
+first, keep every comment already there, and change only what is shown below.
+
+The three differences between modes, and nothing else:
+
+1. `memoryId` is present when editing, absent when creating.
+2. In create mode the district is ALWAYS sent — a new memory has no stored
+   district to preserve, so the "only send what the user changed" guard that
+   protects an edit would silently create it with no district at all.
+3. The route is `/save` when creating, `/update` when editing.
+
+```js
+    async function submitEdit(){
+      const creating = state.modalMode === 'create';
+      const content = $('#editContent').value.trim();
+      if (!content) { showToast('Content cannot be empty.'); return; }
+      const project = $('#editProject').value.trim();
+      const district = $('#editDistrict').value;
+      const rawIntensity = $('#editIntensity').value.trim();
+      const epistemic = $('#editEpistemic').value;
+
+      const body = {
+        content,
+        visibility: $('#editVisibility').value,
+        projectId: project === '' ? null : project,
+        tags: $('#editTags').value.split(',').map(s => s.trim()).filter(Boolean),
+      };
+      if (!creating) body.memoryId = state.editingId;
+      // Editing sends a district only when the user actually changed it, so an
+      // untouched select cannot silently refile a district-less memory. Creating
+      // must always send one -- there is nothing to preserve.
+      if (creating || district !== state.editingDistrict) body.district = district;
+      if (rawIntensity !== '') {
+        const n = Number(rawIntensity);
+        if (!Number.isFinite(n) || n < 0 || n > 1) { showToast('Intensity must be a number between 0 and 1.'); return; }
+        body.intensity = n;
+      }
+      if (epistemic) body.epistemicStatus = epistemic;
+
+      const route = creating ? '/save' : '/update';
+      let res, data;
+      try {
+        res = await fetch(`${BRIDGE}${route}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+        data = await res.json();
+      } catch {
+        showToast('Could not reach the bridge — nothing was saved.');
+        return;
+      }
+      if (!res.ok || !data.ok) { showToast(creating ? 'Create failed.' : 'Update failed.'); return; }
+      $('#editModalBg').classList.remove('open');
+      showToast(creating ? 'Memory created.' : 'Memory updated.');
+    }
+```
+
+**Check this against the function actually in the file before pasting.** If the
+live `submitEdit` does anything this block drops — an extra field, a refresh
+call, a `setWritesDisabled` wrapper — keep it. This block shows the mode
+branching, not permission to discard whatever else is there.
+
+- [ ] **Step 6: Wire the button**
+
+```js
+    els.createBtn.addEventListener('click', () => openCreateModal());
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `npx playwright test -g "the \+ button opens a create modal"`
+Expected: PASS on both projects.
+
+- [ ] **Step 8: Verify the chrome bar survives a seventh control**
+
+Run: `npx playwright test -g "chrome bar keeps every control on screen"`
+Expected: PASS at all five viewports. **If this fails, that is a real defect, not a test to adjust** — the bar has overflowed in production before. Report it and stop rather than loosening the assertion.
+
+- [ ] **Step 9: Run both suites and commit**
+
+Run: `npm test` and `npx playwright test` in the foreground.
+Expected: `npm test` the 2 known failures; playwright 53 passed / 1 skipped.
+
+```bash
+git add scripts/nd-mem-rolodex.html e2e/rolodex-layout.spec.ts
+git commit -m "feat(rolodex): create memories, in one modal with two modes"
+```
+
+---
+
+### Task 3: Long-press to create in context
+
+**Files:**
+- Modify: `scripts/nd-mem-rolodex-helpers.mjs` (`routeGesture`), `scripts/nd-mem-rolodex.html` (pointer handlers, CSS)
+- Test: `test/rolodex-helpers.test.mjs`, `e2e/rolodex-layout.spec.ts`
+
+**Interfaces:**
+- Consumes: `openCreateModal(pressedCard)` from Task 2; the existing `cardIndexAtPoint(clientX, clientY)` and `state.items`.
+- Produces: `routeGesture('longPress', ctx)` returning `'create'` or `'none'`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+Append to `test/rolodex-helpers.test.mjs`:
+
+```js
+test('routeGesture maps a long press to create, except on memory cards', () => {
+  // A memory card is a reading surface; there the gesture belongs to selection.
+  assert.equal(routeGesture('longPress', { level: 'projects', insideReader: false }), 'create');
+  assert.equal(routeGesture('longPress', { level: 'districts', insideReader: false }), 'create');
+  assert.equal(routeGesture('longPress', { level: 'memories', insideReader: false }), 'none');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/rolodex-helpers.test.mjs`
+Expected: FAIL — `routeGesture` returns `'none'` for the projects case (the default branch).
+
+- [ ] **Step 3: Add the gesture**
+
+In `scripts/nd-mem-rolodex-helpers.mjs`, inside `routeGesture`'s switch, add before `default:`:
+
+```js
+    // Long-press creates, carrying the pressed card's context. Not at the
+    // memories level: there the card is a reading surface and the press belongs
+    // to text selection. Right-click is unavailable -- `rightClick` above
+    // already means zoomOut -- so this is the only free gesture.
+    case 'longPress': return level === 'memories' ? 'none' : 'create';
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/rolodex-helpers.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Add the press timer**
+
+In `scripts/nd-mem-rolodex.html`, near the other pointer state (`let pinchStart = 0, dragMoved = 0;`), add:
+
+```js
+    // Long-press: 500ms with the pointer essentially still. Cancelled by any
+    // real movement, a second pointer, or release -- so it can never fire in the
+    // middle of a spin, a pinch, or a reader drag.
+    const LONG_PRESS_MS = 500;
+    const LONG_PRESS_SLOP_PX = 10;
+    let longPressTimer = null;
+    function cancelLongPress(){ if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; } }
+```
+
+In the `pointerdown` handler, after `pressTarget` is set, add:
+
+```js
+      cancelLongPress();
+      if (pointers.size === 1 && H.routeGesture('longPress', { level: state.view.level, insideReader: false }) === 'create') {
+        const px = e.clientX, py = e.clientY;
+        longPressTimer = setTimeout(() => {
+          longPressTimer = null;
+          // Resolve through the geometric hit-test: Chromium cannot hit-test a
+          // rotated side card, so e.target alone would resolve to #scene.
+          const idx = cardIndexAtPoint(px, py);
+          const item = idx >= 0 ? state.items[idx] : null;
+          if (!item) return;
+          // Suppress the click that release would otherwise produce, so the
+          // press does not also dive into the card it just created from.
+          dragMoved = 999;
+          openCreateModal({ kind: item.kind, id: item.id });
+        }, LONG_PRESS_MS);
+      }
+```
+
+In the `pointermove` handler, immediately after `dragMoved` is computed, add:
+
+```js
+      if (longPressTimer && (Math.abs(e.clientX - dragOrigin.x) > LONG_PRESS_SLOP_PX || Math.abs(e.clientY - dragOrigin.y) > LONG_PRESS_SLOP_PX)) cancelLongPress();
+```
+
+In the `pointerup` and `pointercancel` handlers, add `cancelLongPress();` as the first statement. Also cancel when a second pointer arrives — in `pointerdown`, `pointers.size === 1` already gates arming, but an existing timer must die:
+
+```js
+      if (pointers.size > 1) cancelLongPress();
+```
+
+- [ ] **Step 6: Suppress the iOS callout on card surfaces**
+
+Add to the stylesheet, beside the other `.card3d` rules:
+
+```css
+    /* iOS shows a selection callout on a long press. The gesture means "create"
+       on project and district cards, so suppress it there -- but NEVER on
+       .reader-scroll, whose user-select:text is deliberate and is how a memory
+       is read and copied. */
+    #stage:not([data-level="memories"]) .card3d{-webkit-touch-callout:none}
+```
+
+- [ ] **Step 7: Write the browser guard**
+
+Append to `e2e/rolodex-layout.spec.ts`:
+
+```ts
+// Creation in context: the pressed card supplies the defaults.
+test('long-pressing a district card creates with project and district pre-filled', async ({ page }) => {
+  test.slow();
+  // Dive once to reach districts.
+  const box = page.viewportSize()!;
+  await page.mouse.click(box.width / 2, box.height / 2);
+  await page.waitForTimeout(1700);
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level)).toBe('districts');
+
+  const front = await page.evaluate(() => {
+    const f = document.querySelector('#drum .card3d.front') as HTMLElement | null;
+    if (!f) return null;
+    const r = f.getBoundingClientRect();
+    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+  });
+  expect(front, 'a front district card should exist to press').not.toBeNull();
+
+  await page.mouse.move(front!.x, front!.y);
+  await page.mouse.down();
+  await page.waitForTimeout(750); // past LONG_PRESS_MS
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+
+  await expect(page.locator('#editModalBg')).toHaveClass(/open/);
+  expect(await page.locator('#editDistrict').inputValue()).not.toBe('');
+  // The press must not ALSO dive -- the click it would otherwise produce is
+  // suppressed, so we are still at districts.
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level)).toBe('districts');
+});
+```
+
+- [ ] **Step 8: Run the test**
+
+Run: `npx playwright test -g "long-pressing a district card"`
+Expected: PASS on both projects.
+
+- [ ] **Step 9: Run both suites and commit**
+
+Run: `npm test` and `npx playwright test` in the foreground.
+Expected: `npm test` the 2 known failures; playwright 55 passed / 1 skipped.
+
+```bash
+git add scripts/nd-mem-rolodex-helpers.mjs scripts/nd-mem-rolodex.html test/rolodex-helpers.test.mjs e2e/rolodex-layout.spec.ts
+git commit -m "feat(rolodex): long-press a project or district to create in context"
+```
+
+---
+
+# PHASE 2 — SEARCH (Tasks 4–7)
+
+---
+
+### Task 4: The result parser
+
+The one fragile seam in the design, isolated into a pure function and pinned by a contract test in Task 5.
+
+**Files:**
+- Modify: `scripts/nd-mem-rolodex-helpers.mjs`
+- Test: `test/rolodex-helpers.test.mjs`
+
+**Interfaces:**
+- Produces: `parseSearchResults(text) => Array<{ id: string, score: number }>`, exported. Order preserved (the daemon already returns them ranked).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/rolodex-helpers.test.mjs`, adding `parseSearchResults` to the import block:
+
+```js
+const SEARCH_TEXT = [
+  '🔍 Found 2 memories (ranked by BM25 relevance):',
+  '• [0.873] memory_123 — Some title (scholar)',
+  '  first eighty characters of content…',
+  '• [0.412] memory_9 — Another title (merchant)',
+  '  more content here',
+].join('\n');
+
+test('parseSearchResults recovers id and score, in rank order', () => {
+  assert.deepEqual(parseSearchResults(SEARCH_TEXT), [
+    { id: 'memory_123', score: 0.873 },
+    { id: 'memory_9', score: 0.412 },
+  ]);
+});
+
+test('parseSearchResults returns nothing for a no-results response', () => {
+  assert.deepEqual(parseSearchResults('🔍 No memories found matching query: "zzz"'), []);
+});
+
+test('parseSearchResults ignores the did-you-mean suffix', () => {
+  const text = SEARCH_TEXT + '\nDid you mean project_id: alpha?';
+  assert.deepEqual(parseSearchResults(text).map(h => h.id), ['memory_123', 'memory_9']);
+});
+
+test('parseSearchResults ignores the partial-matches block, which also uses bullets', () => {
+  // Partial matches are formatted "• candidate (similarity=0.9, field=..., memories=memory_5, ...)".
+  // Those bullets carry no [score] prefix and must not be read as hits.
+  const text = SEARCH_TEXT +
+    '\n\nPartial matches:\n• alpah (similarity=0.833, field=project_id, memories=memory_5, projects=alpha)';
+  assert.deepEqual(parseSearchResults(text).map(h => h.id), ['memory_123', 'memory_9']);
+});
+
+test('parseSearchResults tolerates junk without throwing', () => {
+  assert.deepEqual(parseSearchResults(''), []);
+  assert.deepEqual(parseSearchResults(null), []);
+  assert.deepEqual(parseSearchResults('completely unrelated text'), []);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/rolodex-helpers.test.mjs`
+Expected: FAIL — no export named `parseSearchResults`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/nd-mem-rolodex-helpers.mjs`:
+
+```js
+// search_memories answers in PROSE, for a reader:
+//   • [0.873] memory_123 — Some title (scholar)
+//     first eighty characters of content…
+// There is no structured search API and the BM25 index is private to
+// server-main.ts, so the bridge recovers the two tokens it cannot get locally --
+// the id and its score -- and hydrates everything else from the snapshot it
+// already reads. Deliberately anchored on the "[score] id" shape: the partial-
+// matches block below the results uses bullets too, but carries no score, so
+// requiring the bracket keeps those out.
+//
+// This regex is the whole fragile seam in the search feature. Its failure mode
+// is SILENT -- zero hits, not an error -- which is why a contract test runs the
+// real tool and asserts this still parses it.
+const SEARCH_HIT_RE = /^\s*[•*-]\s*\[(\d+(?:\.\d+)?)\]\s*(\S+)\s+—/;
+
+export function parseSearchResults(text) {
+  if (typeof text !== 'string' || text === '') return [];
+  const hits = [];
+  for (const line of text.split('\n')) {
+    const m = SEARCH_HIT_RE.exec(line);
+    if (!m) continue;
+    const score = Number(m[1]);
+    if (!Number.isFinite(score)) continue;
+    hits.push({ id: m[2], score });
+  }
+  return hits;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/rolodex-helpers.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/nd-mem-rolodex-helpers.mjs test/rolodex-helpers.test.mjs
+git commit -m "feat(rolodex): parse search hits out of the daemon's prose"
+```
+
+---
+
+### Task 5: The `/search` route and its contract test
+
+**Files:**
+- Modify: `scripts/nd-mem-bridge-server.mjs`
+- Create: `test/bridge-search-contract.test.mjs`
+
+**Interfaces:**
+- Consumes: `parseSearchResults` from Task 4; the existing `runMcpTool(toolName, args)` and `readSnapshot()`.
+- Produces: `GET /search?q=…` returning `{ ok: true, query, total, hits: [{ id, score }] }`.
+
+- [ ] **Step 1: Write the failing contract test**
+
+Create `test/bridge-search-contract.test.mjs`:
+
+```js
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { getFreePort, waitForHealth, stopDaemonOnPort } from "../test-support/daemon.mjs";
+
+// The bridge recovers search hits by PARSING the daemon's prose. That contract
+// is invisible at runtime -- if the tool's wording changes, the parser silently
+// returns zero hits and search just looks broken. This test runs the REAL tool
+// against a seeded store and asserts the parser still recovers what it stored,
+// so a formatting change fails CI instead of production.
+test("the bridge's /search parses what search_memories actually emits", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ndm-search-contract-"));
+  const memoryFile = path.join(tempDir, "memories.json");
+  const bridgePort = await getFreePort();
+  const daemonPort = await getFreePort();
+
+  const bridge = spawn(process.execPath, ["scripts/nd-mem-bridge-server.mjs"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ND_MEM_FILE: memoryFile,
+      NEURODIVERGENT_MEMORY_FILE: memoryFile,
+      NEURODIVERGENT_MEMORY_DIR: tempDir,
+      ND_MEM_BRIDGE_PORT: String(bridgePort),
+      ND_MEM_BRIDGE_OPEN: "0",
+      NEURODIVERGENT_MEMORY_DAEMON_PORT: String(daemonPort),
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let stderr = "";
+  bridge.stderr.on("data", (c) => { stderr += c.toString(); });
+
+  try {
+    await waitForHealth(`http://127.0.0.1:${bridgePort}/health`);
+
+    // Seed through the bridge's own write path so the daemon indexes it.
+    const save = await fetch(`http://127.0.0.1:${bridgePort}/save`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "deployment pipeline rollout checklist", district: "practical_execution" }),
+    });
+    assert.ok(save.ok, `seed save failed: ${save.status}\n${stderr}`);
+
+    const res = await fetch(`http://127.0.0.1:${bridgePort}/search?q=${encodeURIComponent("deployment")}`);
+    assert.ok(res.ok, `search failed: ${res.status}\n${stderr}`);
+    const body = await res.json();
+
+    assert.ok(Array.isArray(body.hits), `hits should be an array: ${JSON.stringify(body)}`);
+    assert.ok(body.hits.length > 0,
+      `THE PARSER RECOVERED NOTHING. Either search_memories' output format changed, or the regex in ` +
+      `parseSearchResults no longer matches it. Response: ${JSON.stringify(body)}\n${stderr}`);
+    for (const hit of body.hits) {
+      assert.match(hit.id, /^memory_/, `hit id should look like a memory id: ${JSON.stringify(hit)}`);
+      assert.ok(Number.isFinite(hit.score), `hit score should be a number: ${JSON.stringify(hit)}`);
+    }
+  } finally {
+    bridge.kill();
+    await stopDaemonOnPort(daemonPort);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/bridge-search-contract.test.mjs`
+Expected: FAIL — `/search` 404s, so `res.ok` is false.
+
+- [ ] **Step 3: Add the route**
+
+In `scripts/nd-mem-bridge-server.mjs`, import the parser near the top:
+
+```js
+import { parseSearchResults } from './nd-mem-rolodex-helpers.mjs';
+```
+
+Add beside the other read routes (after `/memories`):
+
+```js
+// READ ONLY. Ranks through the daemon so the UI sees exactly what an agent
+// would -- same BM25, same tie-breaks -- rather than a second, divergent
+// client-side filter. Only the id and score are parsed out of the tool's prose;
+// everything else the UI needs it already has in the snapshot.
+app.get('/search', async (req, res) => {
+  const query = String(req.query.q ?? '').trim();
+  if (!query) { res.json({ ok: true, query: '', total: 0, hits: [] }); return; }
+  try {
+    const args = { query };
+    if (req.query.district) args.district = String(req.query.district);
+    if (req.query.project_id) args.project_id = String(req.query.project_id);
+    if (req.query.min_score) args.min_score = Number(req.query.min_score);
+    if (req.query.tags) args.tags = String(req.query.tags).split(',').map(s => s.trim()).filter(Boolean);
+
+    const { result } = await runMcpTool('search_memories', args);
+    const text = result?.result?.content?.map(c => c?.text).filter(Boolean).join('\n') ?? '';
+    const hits = parseSearchResults(text);
+    res.json({ ok: true, query, total: hits.length, hits });
+  } catch (error) {
+    res.status(500).json({ ok: false, error: String(error), query });
+  }
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/bridge-search-contract.test.mjs`
+Expected: PASS.
+
+**If the parser recovers nothing**, do NOT loosen the assertion. Print the raw `text` the tool returned, compare it against `SEARCH_HIT_RE`, and fix the regex — that is exactly the failure this test exists to surface. Report the real format you observed.
+
+- [ ] **Step 5: Run the full suite and commit**
+
+Run: `npm test` — expect the 2 known failures plus this new test passing.
+
+```bash
+git add scripts/nd-mem-bridge-server.mjs test/bridge-search-contract.test.mjs
+git commit -m "feat(bridge): serve BM25 search, pinned by a format contract test"
+```
+
+---
+
+### Task 6: The lit predicate and lit-stepping
+
+**Files:**
+- Modify: `scripts/nd-mem-rolodex-helpers.mjs`
+- Test: `test/rolodex-helpers.test.mjs`
+
+**Interfaces:**
+- Consumes: `projectOf`, `districtOf`, `deriveMemories` (already exported).
+- Produces:
+  - `isLit(item, hits, snapshot, view) => boolean` — `item` is `{ id, kind }` where kind is `'project' | 'district' | 'memory'` (exactly the values `itemsForView` emits); `hits` is a `Map<memoryId, score>`; `view` is `state.view`, needed only to scope district matching to the project you are standing in.
+  - `nextLitIndex(items, hits, snapshot, view, from, direction) => number` — returns the next lit index in `direction` (`1` or `-1`), wrapping; returns `from + direction` (wrapped) when nothing is lit.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test/rolodex-helpers.test.mjs`, adding `isLit` and `nextLitIndex` to the import block. `SNAP` is the fixture already defined at the top of that file:
+
+```js
+const WALL = { level: 'projects', projectId: null, districtId: null };
+const IN_ALPHA = { level: 'districts', projectId: 'alpha', districtId: null };
+
+test('isLit lights a memory whose own id matched', () => {
+  const hits = new Map([['mem_1', 0.9]]);
+  assert.equal(isLit({ id: 'mem_1', kind: 'memory' }, hits, SNAP, WALL), true);
+  assert.equal(isLit({ id: 'mem_2', kind: 'memory' }, hits, SNAP, WALL), false);
+});
+
+test('isLit lights a project containing a hit', () => {
+  // mem_1 is project alpha, district practical_execution (see SNAP).
+  const hits = new Map([['mem_1', 0.9]]);
+  assert.equal(isLit({ id: 'alpha', kind: 'project' }, hits, SNAP, WALL), true);
+  assert.equal(isLit({ id: 'beta', kind: 'project' }, hits, SNAP, WALL), false);
+});
+
+test('isLit scopes a district to the project you are standing in', () => {
+  // THE POINT OF THE view ARGUMENT. District names are shared across projects,
+  // not globally unique buckets: SNAP has practical_execution memories under
+  // alpha. Standing inside beta, alpha's hit must NOT light beta's
+  // same-named district card.
+  const hitInAlpha = new Map([['mem_1', 0.9]]);
+  assert.equal(
+    isLit({ id: 'practical_execution', kind: 'district' }, hitInAlpha, SNAP, IN_ALPHA), true);
+  assert.equal(
+    isLit({ id: 'practical_execution', kind: 'district' }, hitInAlpha, SNAP,
+      { level: 'districts', projectId: 'beta', districtId: null }), false);
+  assert.equal(
+    isLit({ id: 'vigilant_monitoring', kind: 'district' }, hitInAlpha, SNAP, IN_ALPHA), false);
+});
+
+test('isLit lights nothing when there are no hits', () => {
+  const none = new Map();
+  assert.equal(isLit({ id: 'mem_1', kind: 'memory' }, none, SNAP, WALL), false);
+  assert.equal(isLit({ id: 'alpha', kind: 'project' }, none, SNAP, WALL), false);
+});
+
+test('nextLitIndex walks to the next lit card and wraps', () => {
+  const items = [
+    { id: 'mem_1', kind: 'memory' },
+    { id: 'mem_2', kind: 'memory' },
+    { id: 'mem_3', kind: 'memory' },
+  ];
+  const hits = new Map([['mem_3', 0.5]]);
+  assert.equal(nextLitIndex(items, hits, SNAP, WALL, 0, 1), 2);
+  // From the only lit card, forward wraps back to itself.
+  assert.equal(nextLitIndex(items, hits, SNAP, WALL, 2, 1), 2);
+  assert.equal(nextLitIndex(items, hits, SNAP, WALL, 0, -1), 2);
+});
+
+test('nextLitIndex falls back to ordinary stepping when nothing is lit', () => {
+  const items = [
+    { id: 'mem_1', kind: 'memory' },
+    { id: 'mem_2', kind: 'memory' },
+  ];
+  const none = new Map();
+  assert.equal(nextLitIndex(items, none, SNAP, WALL, 0, 1), 1);
+  assert.equal(nextLitIndex(items, none, SNAP, WALL, 1, 1), 0);
+  assert.equal(nextLitIndex(items, none, SNAP, WALL, 0, -1), 1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/rolodex-helpers.test.mjs`
+Expected: FAIL — no exports named `isLit` / `nextLitIndex`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `scripts/nd-mem-rolodex-helpers.mjs`:
+
+```js
+// One rule at every level: a card is lit if IT, or anything inside it, matched.
+// That is what turns a search into a drill-down -- query at the wall, see which
+// projects light, dive into a lit one, see which districts light -- instead of
+// needing a separate results view.
+export function isLit(item, hits, snapshot, view = {}) {
+  if (!hits || hits.size === 0 || !item) return false;
+  if (item.kind === 'memory') return hits.has(item.id);
+  const memories = Object.values(snapshot?.memories ?? {});
+  if (item.kind === 'project') {
+    return memories.some(m => hits.has(m.id) && projectOf(m) === item.id);
+  }
+  if (item.kind === 'district') {
+    // Scoped to the project being viewed. District names are shared across
+    // projects, not globally unique buckets -- without this, standing inside
+    // project beta would light its practical_execution card because something
+    // in ALPHA's practical_execution matched.
+    const scope = view.projectId;
+    return memories.some(m => hits.has(m.id)
+      && districtOf(m) === item.id
+      && (scope == null || projectOf(m) === scope));
+  }
+  return false;
+}
+
+// Stepping skips dark cards while a search is active, so a 364-memory bucket
+// stays fast. With nothing lit at this level, fall back to ordinary stepping
+// rather than refusing to move -- a search that matches nothing here must not
+// strand the drum.
+export function nextLitIndex(items, hits, snapshot, view, from, direction) {
+  const count = items.length;
+  if (!count) return from;
+  const step = direction >= 0 ? 1 : -1;
+  const plain = ((from + step) % count + count) % count;
+  if (!hits || hits.size === 0) return plain;
+  for (let i = 1; i <= count; i++) {
+    const idx = ((from + step * i) % count + count) % count;
+    if (isLit(items[idx], hits, snapshot, view)) return idx;
+  }
+  return plain;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/rolodex-helpers.test.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/nd-mem-rolodex-helpers.mjs test/rolodex-helpers.test.mjs
+git commit -m "feat(rolodex): light a card when it or anything inside it matches"
+```
+
+---
+
+### Task 7: Search in the page
+
+**Files:**
+- Modify: `scripts/nd-mem-rolodex.html` — markup, CSS, `state`, `updateChrome`, `updateFrontCard`/`buildDrum` render path, `stepBy`
+- Test: `e2e/rolodex-layout.spec.ts`
+
+**Interfaces:**
+- Consumes: `H.parseSearchResults` (via the bridge, not directly), `H.isLit`, `H.nextLitIndex`; `GET /search`.
+- Produces: `state.search = { query: string, hits: Map<string, number> }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `e2e/rolodex-layout.spec.ts`:
+
+```ts
+// Search DIMS rather than filtering or reordering: a 3D ring's one advantage
+// over a list is that "my card was over there" stays true.
+test('search dims non-matches without moving a single card', async ({ page }) => {
+  test.slow();
+  expect(await diveToMemories(page)).toBe('memories');
+
+  const before = await page.evaluate(() => [...document.querySelectorAll('#drum .card3d')]
+    .map(c => { const r = c.getBoundingClientRect(); return { idx: (c as HTMLElement).dataset.idx, x: Math.round(r.x), y: Math.round(r.y) }; }));
+
+  // Query a word certain to appear in this store's own memories.
+  await page.locator('#searchInput').fill('memory');
+  await page.waitForTimeout(1200); // 250ms debounce + daemon round trip
+
+  const after = await page.evaluate(() => [...document.querySelectorAll('#drum .card3d')]
+    .map(c => { const r = c.getBoundingClientRect(); return { idx: (c as HTMLElement).dataset.idx, x: Math.round(r.x), y: Math.round(r.y) }; }));
+  expect(after, 'search must not move any card').toEqual(before);
+
+  const dimmed = await page.evaluate(() =>
+    document.querySelectorAll('#drum .card3d.search-dim').length);
+  const lit = await page.evaluate(() =>
+    document.querySelectorAll('#drum .card3d.search-hit').length);
+  expect(lit + dimmed, 'every rendered card should be classified once a search is active')
+    .toBe(after.length);
+  expect(lit, 'the query should match at least one memory in this store').toBeGreaterThan(0);
+
+  // Clearing restores everything.
+  await page.locator('#searchInput').fill('');
+  await page.waitForTimeout(600);
+  expect(await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-dim').length)).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx playwright test -g "search dims non-matches"`
+Expected: FAIL — locator `#searchInput` resolves to nothing.
+
+- [ ] **Step 3: Add the input**
+
+In `scripts/nd-mem-rolodex.html`, inside `#locus`, before `#crumb`:
+
+```html
+      <input id="searchInput" type="search" placeholder="Search memories…" autocomplete="off" spellcheck="false" />
+```
+
+CSS beside the `#locus` rules:
+
+```css
+    /* Shares the band's row. While a query is active the coordinate hides: the
+       coordinate answers "where am I", the query answers "what am I looking
+       for", and both are rarely needed at once. The row already wraps at every
+       width and is already guarded at five viewports. */
+    #searchInput{flex:1 1 12rem;min-width:0;padding:4px 10px;border-radius:999px;
+      border:1px solid var(--surfaceBorder);background:var(--wash);color:var(--text);
+      font:inherit;font-size:.82rem}
+    #searchInput::placeholder{color:var(--faint)}
+    #locus.searching #crumb{display:none}
+    /* Dim the misses; light the hits. Composes with the existing card states
+       rather than replacing them -- .front, .flipped and the ::after affordance
+       all still apply. */
+    .card3d.search-dim{opacity:.25}
+    .card3d.search-hit{border-color:var(--primary)}
+```
+
+- [ ] **Step 4: Add state and the fetch**
+
+Add to the `state` object:
+
+```js
+      search: { query: '', hits: new Map() },
+```
+
+Add near the other input wiring:
+
+```js
+    // 250ms debounce, and a later query always wins: /search is a daemon round
+    // trip, so a call per keystroke would both lag and land out of order.
+    let searchTimer = null;
+    let searchSeq = 0;
+    async function runSearch(query){
+      const seq = ++searchSeq;
+      if (!query) { state.search = { query: '', hits: new Map() }; renderSearchState(); return; }
+      try {
+        const res = await fetch(`${BRIDGE}/search?q=${encodeURIComponent(query)}`);
+        const data = await res.json();
+        if (seq !== searchSeq) return; // superseded
+        state.search = { query, hits: new Map((data.hits || []).map(h => [h.id, h.score])) };
+      } catch {
+        if (seq !== searchSeq) return;
+        state.search = { query, hits: new Map() };
+        showToast('Search could not reach the bridge.');
+      }
+      renderSearchState();
+    }
+    els.searchInput.addEventListener('input', () => {
+      const q = els.searchInput.value.trim();
+      els.locus.classList.toggle('searching', q !== '');
+      clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => runSearch(q), 250);
+    });
+    els.searchInput.addEventListener('keydown', (e) => {
+      // Escape clears the query. The modal handler owns Escape otherwise and
+      // runs first, so this only fires when the input has focus and no modal is open.
+      if (e.key === 'Escape') { e.stopPropagation(); els.searchInput.value = ''; els.locus.classList.remove('searching'); clearTimeout(searchTimer); runSearch(''); }
+    });
+```
+
+Add `searchInput: $('#searchInput'), locus: $('#locus'),` to the `els` object.
+
+- [ ] **Step 5: Render the lit state**
+
+```js
+    // Applied to the rendered window only, and re-applied after any rebuild.
+    function renderSearchState(){
+      const { hits } = state.search;
+      els.drum.querySelectorAll('.card3d[data-idx]').forEach((el) => {
+        const item = state.items[Number(el.dataset.idx)];
+        if (!item || !hits.size) { el.classList.remove('search-dim', 'search-hit'); return; }
+        const lit = H.isLit(item, hits, state.snapshot, state.view);
+        el.classList.toggle('search-hit', lit);
+        el.classList.toggle('search-dim', !lit);
+      });
+    }
+```
+
+Call `renderSearchState()` at the end of `updateFrontCard`, so every rebuild and every front change re-applies it.
+
+- [ ] **Step 6: Make stepping skip dark cards**
+
+In `stepBy`, replace the index computation for the cylinder path. Find:
+
+```js
+      const raw = state.frontIndex + n;
+```
+
+and precede it with:
+
+```js
+      // While a search is active, step hit-to-hit: a 364-memory bucket is not
+      // worth spinning through one dark card at a time.
+      if (state.search.hits.size) {
+        const target = H.nextLitIndex(state.items, state.search.hits, state.snapshot, state.view, state.frontIndex, n > 0 ? 1 : -1);
+        state.stepTarget = H.rotationForCard(target, state.layout);
+        state.frontIndex = target;
+        return;
+      }
+```
+
+- [ ] **Step 7: Run the test**
+
+Run: `npx playwright test -g "search dims non-matches"`
+Expected: PASS on both projects.
+
+- [ ] **Step 8: Add the drill-down guard**
+
+```ts
+// The same query means something at every depth: one call, held once,
+// re-interpreted one level deeper each time you dive.
+test('a search at the wall survives a dive and lights the districts inside', async ({ page }) => {
+  test.slow();
+  await page.locator('#searchInput').fill('memory');
+  await page.waitForTimeout(1200);
+  const litProjects = await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-hit').length);
+  expect(litProjects, 'at least one project should contain a match').toBeGreaterThan(0);
+
+  // Dive into the centred card, which the search left in place.
+  const box = page.viewportSize()!;
+  await page.mouse.click(box.width / 2, box.height / 2);
+  await page.waitForTimeout(1700);
+
+  expect(await page.locator('#searchInput').inputValue(), 'the query must survive the dive').toBe('memory');
+  const stillClassified = await page.evaluate(() =>
+    document.querySelectorAll('#drum .card3d.search-hit, #drum .card3d.search-dim').length);
+  expect(stillClassified, 'the deeper level should be classified by the same query').toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 9: Run both suites and commit**
+
+Run: `npm test` and `npx playwright test` in the foreground.
+Expected: `npm test` the 2 known failures; playwright 59 passed / 1 skipped.
+
+```bash
+git add scripts/nd-mem-rolodex.html e2e/rolodex-layout.spec.ts
+git commit -m "feat(rolodex): search dims the misses and keeps every card in place"
+```
+
+---
+
+## Post-implementation
+
+- [ ] **Device confirmation on the iPhone.** Long-press callout suppression and the search input's mobile keyboard cannot be gated by Playwright's WebKit, which is tap-only and exposes no CDP. Reload the page (served from disk per request); restart the bridge only if a server-side file changed.
+- [ ] **Update the backlog index** (`memory_1655`) to close the search and creation entries, and mark `memory_1644` / `memory_1664` done.
+- [ ] **Write the HANDOFF memory** in `practical_execution`.
+- [ ] Do **not** push or open a PR until the user asks. PRs target `development`; the remote is `neurodivergent-memory`.

--- a/docs/superpowers/plans/2026-08-02-rolodex-search-and-creation.md
+++ b/docs/superpowers/plans/2026-08-02-rolodex-search-and-creation.md
@@ -616,7 +616,7 @@ git commit -m "feat(rolodex): parse search hits out of the daemon's prose"
 - Create: `test/bridge-search-contract.test.mjs`
 
 **Interfaces:**
-- Consumes: `parseSearchResults` from Task 4; the existing `runMcpTool(toolName, args)` and `readSnapshot()`.
+- Consumes: `parseSearchResults` from Task 4; the existing `runMcpTool(toolName, args)`. (NOT `readSnapshot()` — the route returns `{id, score}` only and hydrates nothing; the page does that from the snapshot it already holds.)
 - Produces: `GET /search?q=…` returning `{ ok: true, query, total, hits: [{ id, score }] }`.
 
 - [ ] **Step 1: Write the failing contract test**

--- a/docs/superpowers/specs/2026-08-02-rolodex-search-and-creation-design.md
+++ b/docs/superpowers/specs/2026-08-02-rolodex-search-and-creation-design.md
@@ -70,8 +70,9 @@ carousel — and answering it twice would produce two answers.
 `tags`, `min_score` passed straight through (the tool already accepts all of them).
 
 It calls `search_memories` via the existing `runMcpTool`, then **parses only the
-`[score]` and `memory_id` pairs** out of the response and hydrates full records from
-the snapshot it already reads for `/memories`. Response:
+`[score]` and `memory_id` pairs** out of the response. The route returns those two
+fields and nothing else; the **page** hydrates full records from the snapshot it
+already holds. Response:
 
 ```json
 { "hits": [ { "id": "memory_123", "score": 0.873 } ], "total": 12, "query": "deploy" }
@@ -79,6 +80,21 @@ the snapshot it already reads for `/memories`. Response:
 
 **Rulings:**
 
+- **`search_memories` returns the WHOLE store, and the bridge must drop the
+  zeroes.** Its `min_score` defaults to `0`; BM25 scores a document containing
+  none of the query terms exactly `0`, and the Robertson IDF variant it uses is
+  always positive, so a score is never negative. `0 >= 0` passes the threshold,
+  and there is no result cap in the tool — so an unfiltered response ranks the
+  real matches first and then lists **every other memory in the store at
+  `0.000`**. Against a design that dims rather than filters, that means every
+  card is lit and the query discriminates nothing. `/search` therefore keeps only
+  `score > 0`. Filtered at the bridge rather than by passing a small epsilon as
+  `min_score`, because the tool's schema documents `minimum: 0` and this is the
+  only place the reason can be written down. Cost: scores arrive through prose at
+  three decimals, so a genuine match normalising below `0.0005` of the top hit
+  reads as `0.000` and is dropped with the misses — it takes a single very common
+  query term plus an extreme document-length spread, and a card missing from the
+  lit set is a far smaller failure than every card being in it.
 - **Parse minimally.** Recovering two tokens per line is a much narrower contract
   than parsing titles, archetypes and truncated previews — and everything else is
   already available locally, at full fidelity, in the snapshot.
@@ -199,16 +215,24 @@ is for". Nobody long-presses a card to discover what happens.
 
 **Contract** (`test/bridge-search-contract.test.mjs`): a real `search_memories`
 call against a seeded temp store, asserting the parser recovers the expected ids.
-Guards the one fragile seam in the design.
+Guards the one fragile seam in the design. Seeds **two** memories, one of which
+shares no token with the query, and asserts that one is **absent** from the hits —
+with a single seed, "returned the match" and "returned the entire store" are the
+same response, and the entire store is what the tool actually returns (see §2).
 
 **Browser** (`e2e/rolodex-layout.spec.ts`):
 - searching dims non-matches and leaves every card's position unchanged
-  (positions captured before and after and asserted identical)
+  (positions captured before and after and asserted identical), asserting the lit
+  and dimmed counts **separately** — summing them passes when nothing dims
 - a project card lights when a memory inside it matches
 - the query survives a dive: search at the wall, dive into a lit project, and the
   matching districts are lit without re-typing
-- stepping skips to the next lit card while a search is active
-- clearing restores opacity and the coordinate
+- stepping skips to the next lit card while a search is active, and takes the
+  short way round the drum to reach it
+- clearing restores opacity (the coordinate's reappearance is CSS-only —
+  `#locus.searching` is toggled by the same input handler that clears the query —
+  and is left to the "search must not move a card" guard rather than asserted
+  separately)
 - `+` opens with the correct pre-fill at each level
 - long-press on a district card pre-fills project and district
 - the chrome bar keeps every control on screen at all five viewports **with the

--- a/docs/superpowers/specs/2026-08-02-rolodex-search-and-creation-design.md
+++ b/docs/superpowers/specs/2026-08-02-rolodex-search-and-creation-design.md
@@ -1,0 +1,246 @@
+# Rolodex Search & Creation — Design
+
+**Date:** 2026-08-02
+**Status:** Approved design, pending implementation plan
+**Author:** brainstormed with Claude (Opus 5)
+**Builds on:** `docs/superpowers/specs/2026-07-31-rolodex-legibility-design.md` (shipped, PR #161)
+**Origin:** the two capabilities the classic app has that the rolodex does not
+
+## Goal
+
+The rolodex can read, navigate, rename, and edit. It cannot **find** and it cannot
+**create**. Both gaps were raised by the user after the legibility slice shipped:
+
+> "we're missing a search function in the new UX. We already have it in the old."
+
+> "along with the search, being able to create new memories in the rolodex. The old
+> UX had it, this one does not."
+
+Until both exist, the rolodex cannot replace the classic app for a full session,
+which is the stated direction of travel.
+
+### Two corrections to the framing, established before designing
+
+**The classic app's search is not what it was assumed to be.** It is a plain
+client-side substring match over concatenated fields
+(`` `${name} ${content} ${tags} ${district}`.toLowerCase().includes(q) ``,
+`scripts/nd-mem-mcp-app-bridge.html`). No semantics, no ranking. So agent-parity
+search is **new capability**, not a port. This is stated here so nobody later
+"simplifies" it back into `.includes()` on the grounds that the other app does that.
+
+**`search_memories` returns prose, not data.** The tool formats results for a reader:
+
+```
+🔍 Found 12 memories (ranked by BM25 relevance):
+• [0.873] memory_123 — Some title (scholar)
+  first eighty characters of content…
+```
+
+There is no structured search API. The BM25 index is a private class inside
+`src/server-main.ts`, not a reusable module. Every option below is shaped by that.
+
+## Non-goals
+
+- Extracting the BM25 scorer into a shared module. Architecturally cleaner, but it
+  refactors the internals of the agent-critical search path in a 7,000-line file —
+  a larger and riskier change than the feature it would serve.
+- A results view with its own place in the navigation tree. Search annotates the
+  drum you are looking at; it does not build a new one. See §3.
+- Search-as-navigation ("take me to the match"). The drill-down in §3 covers the
+  same need using navigation that already exists.
+- Any change to the classic app, to drum geometry, or to the nav tree's structure.
+- Editing from the create modal, or creating from the edit modal. One component,
+  two modes, one direction each (§4).
+
+## 1. Scope and phasing
+
+One spec, **two implementation phases**, in this order:
+
+1. **Creation** — nearly self-contained. `POST /save` already exists and routes to
+   `store_memory`; the work is UI plus an autofill resolver.
+2. **Search** — larger, and carries the only real risk in the design (§2).
+
+Phased this way so creation can land even if search needs another round. They are
+designed together because they share one question — where input lives in a 3D
+carousel — and answering it twice would produce two answers.
+
+## 2. Search: obtaining the ranking
+
+**The bridge gains `GET /search?q=…`**, with optional `district`, `project_id`,
+`tags`, `min_score` passed straight through (the tool already accepts all of them).
+
+It calls `search_memories` via the existing `runMcpTool`, then **parses only the
+`[score]` and `memory_id` pairs** out of the response and hydrates full records from
+the snapshot it already reads for `/memories`. Response:
+
+```json
+{ "hits": [ { "id": "memory_123", "score": 0.873 } ], "total": 12, "query": "deploy" }
+```
+
+**Rulings:**
+
+- **Parse minimally.** Recovering two tokens per line is a much narrower contract
+  than parsing titles, archetypes and truncated previews — and everything else is
+  already available locally, at full fidelity, in the snapshot.
+- **The parser is pure and exported** from `scripts/nd-mem-rolodex-helpers.mjs`,
+  unit-tested against captured fixtures covering: normal results, zero results,
+  the `Did you mean project_id: …?` suffix, and the `Partial matches:` block.
+- **A contract test pins the format.** It runs a real `search_memories` against a
+  seeded temp store and asserts the parser recovers the expected ids. Both sides
+  live in this repo, so a formatting change to the tool breaks CI rather than
+  silently returning zero hits in production. This test is the whole reason
+  parsing is acceptable; without it this approach should not ship.
+- The bridge never writes here. `/search` is a read path and must stay one.
+
+## 3. Search: effect on the drum
+
+State: `state.search = { query, hits }` where `hits` is a `Map<memoryId, score>`.
+Empty query means no search is active and nothing is dimmed.
+
+**One rule at every level — a card is lit if it, or anything inside it, matches:**
+
+| level | a card is lit when |
+|---|---|
+| memories | its own id is in `hits` |
+| districts | any memory in that district is in `hits` |
+| projects | any memory in that project is in `hits` |
+
+This makes search a **guided drill-down**: query at the wall, see which projects
+light up, dive into a lit one, see which districts light, dive again, find the
+memory. It reuses the navigation that already exists rather than inventing a
+results view, and it gives the same query a meaning at every depth.
+
+**The query is global and survives navigation.** One `search_memories` call returns
+matches from the whole store; `hits` is held once and the lit-predicate re-evaluates
+against it at whatever level you are standing on. That is what makes the drill-down
+work: diving does not re-run the search, it re-interprets the same result set one
+level deeper. The query persists across dives and zoom-outs until explicitly
+cleared, and the input shows it the whole time so it is never a hidden mode.
+
+**Input is debounced at 250ms** and a new query supersedes any in-flight request —
+`/search` is a daemon round trip, so a call per keystroke would both lag and land
+out of order. An empty or whitespace-only query clears rather than searching.
+
+**Rendering.** Non-matching cards drop to `opacity:.25` (composing with, not
+replacing, the existing `.card3d:not(.front)` value of `.55` — the dimmed state is
+the lower of the two). Matching cards keep their normal opacity and gain a
+`--primary` border tint; no size, position or z-order change. **Positions never
+change.** That is the whole
+point of choosing this over filtering or reordering: a 3D ring's one advantage over
+a list is that "my card was over that way" remains true, and both alternatives
+destroy it. Filtering additionally can leave the user facing an empty stage.
+
+**Stepping.** While a search is active, `◀ ▶` and the arrow keys advance to the next
+**lit** card rather than the next card, so a 364-memory bucket stays fast. With no
+search active, behaviour is unchanged. If a search is active and nothing is lit at
+this level, stepping falls back to normal stepping rather than refusing to move.
+
+**Where the input lives.** In the location band's row. It replaces the coordinate
+while active and restores it on clear: the coordinate answers *where am I*, the
+query answers *what am I looking for*, and both are rarely needed at once. That row
+already wraps at every width and is already guarded at five viewports, so it is the
+one surface with an overflow test pointed at it.
+
+**Clearing** restores full opacity everywhere and returns the coordinate. Escape
+clears the query when the input has focus (the modal-close handler already owns
+Escape otherwise and must keep priority).
+
+## 4. Creation
+
+**A round `+` in the chrome bar's right cluster**, beside `?`, theme and Classic
+view. Placement reasoning is in §6.
+
+**One modal, two modes.** The rolodex's existing edit modal gains a create mode
+rather than gaining a sibling. The two apps' near-duplicate modals have *already*
+drifted once — that divergence was a code-review finding — and a third copy in the
+same repo would drift too. Create mode differs by: title, submit label, no
+`memoryId`, and posting to `/save` instead of `/update`.
+
+**Autofill escalates with depth**, which is what the coordinate already means:
+
+| opened from | pre-fills |
+|---|---|
+| `+` at projects | nothing |
+| `+` at districts | project |
+| `+` at memories | project + district |
+| long-press a project card | that project |
+| long-press a district card | that project + district |
+
+The resolver is a pure function of `(view, pressedCard)` and is unit-tested.
+
+**Long-press** is a new `longPress` kind in `H.routeGesture` returning `'create'`.
+
+- It resolves the pressed card through the existing `cardIndexAtPoint`, so rotated
+  side cards work — Chromium cannot DOM-hit-test them.
+- It is **not** bound at the memories level: there the card is a reading surface and
+  the gesture belongs to text selection.
+- On iOS it must suppress the native callout without disturbing `.reader-scroll`'s
+  deliberate `user-select: text`.
+- Right-click is **not** available: `contextmenu` is already bound to `zoomOut`
+  via the gesture table's `rightClick` case. Long-press is the only free gesture.
+
+**Why both a button and a gesture.** They do different jobs. The button makes
+creation discoverable; the gesture makes it fast and contextual. Shipping only the
+gesture would repeat the mistake this project already made once, when a bare `›`
+affordance shipped and was reported as "confusing as to what that means or what it
+is for". Nobody long-presses a card to discover what happens.
+
+**Submission** posts to `/save`. Intensity reuses the validation added in PR #161:
+0–1, finite, toast on invalid, omitted when the field is empty.
+
+## 5. Testing
+
+**Unit** (`test/rolodex-helpers.test.mjs`, pure functions in the helpers):
+- the `[score] id` parser, including zero-result and did-you-mean shapes
+- the "is this container lit" predicate at all three levels
+- the autofill resolver for all five entry points in §4
+- lit-stepping: next-lit-index from a given index, including the wrap and the
+  no-lit-cards fallback to ordinary stepping
+
+**Contract** (`test/bridge-search-contract.test.mjs`): a real `search_memories`
+call against a seeded temp store, asserting the parser recovers the expected ids.
+Guards the one fragile seam in the design.
+
+**Browser** (`e2e/rolodex-layout.spec.ts`):
+- searching dims non-matches and leaves every card's position unchanged
+  (positions captured before and after and asserted identical)
+- a project card lights when a memory inside it matches
+- the query survives a dive: search at the wall, dive into a lit project, and the
+  matching districts are lit without re-typing
+- stepping skips to the next lit card while a search is active
+- clearing restores opacity and the coordinate
+- `+` opens with the correct pre-fill at each level
+- long-press on a district card pre-fills project and district
+- the chrome bar keeps every control on screen at all five viewports **with the
+  seventh control present**
+
+`npm test` stays `node --test`; browser specs stay in `e2e/`.
+
+## 6. Risks and constraints
+
+- **The parser is the sharp edge.** Its failure mode is silent — zero hits, not an
+  error. The contract test is what makes it acceptable; weakening that test
+  re-arms the risk invisibly.
+- **A seventh chrome control** goes onto a bar that has overflowed in production
+  before. Chosen anyway because it is the one surface with a guard already testing
+  five viewports, and the band's `flex-wrap` gives it somewhere to go. A floating
+  button would have been a fifth fixed element needing to stay clear of the card,
+  hud, spin buttons and minimap — four elements that all collided with something
+  during the previous slice.
+- **Dimming must not fight the existing card states.** `.card3d` already carries
+  `.front`, `.flipped` and the `:not(.front)::after` affordance; the search state is
+  another axis and must compose with all three rather than override them.
+- Playwright's WebKit is tap-only and exposes no CDP, so long-press behaviour on
+  iOS — especially callout suppression — needs device confirmation. It cannot be
+  gated by the browser suite.
+
+## 7. Files
+
+| File | Change |
+|---|---|
+| `scripts/nd-mem-bridge-server.mjs` | `GET /search` route |
+| `scripts/nd-mem-rolodex-helpers.mjs` | result parser, lit-predicate, autofill resolver |
+| `scripts/nd-mem-rolodex.html` | search input, dim rendering, lit-stepping, `+` button, create mode, long-press |
+| `test/rolodex-helpers.test.mjs` | unit coverage for the three pure functions |
+| `test/bridge-search-contract.test.mjs` | the format contract test |
+| `e2e/rolodex-layout.spec.ts` | the browser guards in §5 |

--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -870,3 +870,22 @@ test('a search at the wall survives a dive and lights the districts inside', asy
     document.querySelectorAll('#drum .card3d.search-hit, #drum .card3d.search-dim').length);
   expect(stillClassified, 'the deeper level should be classified by the same query').toBeGreaterThan(0);
 });
+
+// window's contextmenu handler predates the search box and only exempted
+// modal text fields from its "right-click zooms out" behaviour -- #searchInput
+// is a text field that lives outside any modal, so a right-click (or an iOS
+// long-press) on it must keep the native menu instead of navigating away
+// mid-query.
+test('right-clicking the search input does not navigate the drum', async ({ page }) => {
+  test.slow();
+  expect(await diveToMemories(page)).toBe('memories');
+  await page.locator('#searchInput').fill('memory');
+  await page.waitForTimeout(1200);
+
+  await page.locator('#searchInput').click({ button: 'right' });
+  await page.waitForTimeout(1700); // zoomOut's transitionTo takes two ~700ms halves if it fires
+
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level),
+    'a right-click in the search box must not zoom the drum out').toBe('memories');
+  expect(await page.locator('#searchInput').inputValue(), 'the query must survive a right-click').toBe('memory');
+});

--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -760,3 +760,33 @@ test('the + button opens a create modal pre-filled from where you are standing',
   expect(await page.locator('#editDistrict').inputValue()).toBe(where.district);
   await page.locator('#editCancelBtn').click();
 });
+
+// Creation in context: the pressed card supplies the defaults.
+test('long-pressing a district card creates with project and district pre-filled', async ({ page }) => {
+  test.slow();
+  // Dive once to reach districts.
+  const box = page.viewportSize()!;
+  await page.mouse.click(box.width / 2, box.height / 2);
+  await page.waitForTimeout(1700);
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level)).toBe('districts');
+
+  const front = await page.evaluate(() => {
+    const f = document.querySelector('#drum .card3d.front') as HTMLElement | null;
+    if (!f) return null;
+    const r = f.getBoundingClientRect();
+    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+  });
+  expect(front, 'a front district card should exist to press').not.toBeNull();
+
+  await page.mouse.move(front!.x, front!.y);
+  await page.mouse.down();
+  await page.waitForTimeout(750); // past LONG_PRESS_MS
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+
+  await expect(page.locator('#editModalBg')).toHaveClass(/open/);
+  expect(await page.locator('#editDistrict').inputValue()).not.toBe('');
+  // The press must not ALSO dive -- the click it would otherwise produce is
+  // suppressed, so we are still at districts.
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level)).toBe('districts');
+});

--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -735,3 +735,28 @@ test('spinning to another card resets the flip to the front', async ({ page }) =
   expect(back!.readerShown, 'the re-selected card should show its text again').toBe(true);
   expect(back!.metaShown, "the re-selected card should not still show its earlier-opened meta pane").toBe(false);
 });
+
+// The rolodex could read, navigate, rename and edit -- but not create. The
+// classic app has had a New Card form all along.
+test('the + button opens a create modal pre-filled from where you are standing', async ({ page }) => {
+  test.slow();
+  // At the wall: nothing inherited.
+  await page.locator('#createBtn').click();
+  await expect(page.locator('#editModalBg')).toHaveClass(/open/);
+  expect(await page.locator('#editModalTitle').textContent()).toMatch(/new memory/i);
+  expect(await page.locator('#editProject').inputValue()).toBe('');
+  await page.locator('#editCancelBtn').click();
+
+  // At memories depth: project AND district inherited.
+  expect(await diveToMemories(page)).toBe('memories');
+  const where = await page.evaluate(() => {
+    const segs = [...document.querySelectorAll('#crumb .seg')];
+    return { project: (segs[1]?.getAttribute('title') ?? segs[1]?.textContent ?? '').trim(),
+             district: (segs[2]?.getAttribute('title') ?? segs[2]?.textContent ?? '').trim() };
+  });
+  await page.locator('#createBtn').click();
+  await expect(page.locator('#editModalBg')).toHaveClass(/open/);
+  expect(await page.locator('#editProject').inputValue()).toBe(where.project);
+  expect(await page.locator('#editDistrict').inputValue()).toBe(where.district);
+  await page.locator('#editCancelBtn').click();
+});

--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -770,13 +770,28 @@ test('long-pressing a district card creates with project and district pre-filled
   await page.waitForTimeout(1700);
   expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level)).toBe('districts');
 
+  // settleLayout, not a flat wait: the neighbouring Rename test's own comment
+  // spells out why measuring a card's rect mid-rebuild is a trap -- the press
+  // lands where the card WAS. This test measures a rect too, so it needs the
+  // same guarantee.
+  await settleLayout(page);
+
+  // Capture WHICH card is being pressed in the same evaluate that measures it,
+  // so the assertions below can name it. A district card's <h2> is its id.
   const front = await page.evaluate(() => {
     const f = document.querySelector('#drum .card3d.front') as HTMLElement | null;
     if (!f) return null;
     const r = f.getBoundingClientRect();
-    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    const segs = [...document.querySelectorAll('#crumb .seg')];
+    return {
+      x: r.x + r.width / 2,
+      y: r.y + r.height / 2,
+      districtId: (f.querySelector('h2')?.textContent ?? '').trim(),
+      projectId: (segs[1]?.getAttribute('title') ?? segs[1]?.textContent ?? '').trim(),
+    };
   });
   expect(front, 'a front district card should exist to press').not.toBeNull();
+  expect(front!.districtId, 'the pressed card should name a district').not.toBe('');
 
   await page.mouse.move(front!.x, front!.y);
   await page.mouse.down();
@@ -785,7 +800,15 @@ test('long-pressing a district card creates with project and district pre-filled
   await page.waitForTimeout(300);
 
   await expect(page.locator('#editModalBg')).toHaveClass(/open/);
-  expect(await page.locator('#editDistrict').inputValue()).not.toBe('');
+  // Assert the INHERITED values, not merely "not empty". `not.toBe('')` was
+  // satisfied by openCreateModal's own `|| 'practical_execution'` fallback, so
+  // it passed identically whether the pressed card's context was inherited or
+  // dropped on the floor -- and #editProject was never read at all, which is
+  // half of what the test's name promises.
+  expect(await page.locator('#editDistrict').inputValue(),
+    'the modal should inherit the district of the card that was pressed').toBe(front!.districtId);
+  expect(await page.locator('#editProject').inputValue(),
+    'the modal should inherit the project being stood in').toBe(front!.projectId);
   // The press must not ALSO dive -- the click it would otherwise produce is
   // suppressed, so we are still at districts.
   expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level)).toBe('districts');
@@ -820,6 +843,34 @@ test("long-pressing a project card's Rename control opens rename, not create", a
   await expect(page.locator('#editModalBg')).not.toHaveClass(/open/);
 });
 
+// The gesture arms on the level read at pointerdown but resolves the pressed
+// card 500ms later, while a dive holds `transitioning` for ~1400ms and flips
+// state.view a third of the way through it. A press begun inside that window
+// armed at districts (where a long press means "create") and fired at memories
+// (where routeGesture forbids it), opening a create modal over a memory card.
+test('a long press begun during a dive does not create at the level it arrives in', async ({ page }) => {
+  test.slow();
+  const box = page.viewportSize()!;
+  await settleLayout(page);
+  await page.mouse.click(box.width / 2, box.height / 2); // wall -> districts
+  await page.waitForTimeout(1700);
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level)).toBe('districts');
+
+  await settleLayout(page);
+  await page.mouse.click(box.width / 2, box.height / 2); // districts -> memories, now in flight
+  await page.waitForTimeout(300); // inside the 200-700ms window, before state.view flips
+  await page.mouse.move(box.width / 2, box.height / 2);
+  await page.mouse.down();
+  await page.waitForTimeout(750); // past LONG_PRESS_MS, so it would fire after the flip
+  await page.mouse.up();
+  await page.waitForTimeout(1200); // let the rest of the dive land
+
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level),
+    'the dive should have completed normally').toBe('memories');
+  await expect(page.locator('#editModalBg'),
+    'a press armed mid-dive must not open a create modal in the level it lands in').not.toHaveClass(/open/);
+});
+
 // Search DIMS rather than filtering or reordering: a 3D ring's one advantage
 // over a list is that "my card was over there" stays true.
 test('search dims non-matches without moving a single card', async ({ page }) => {
@@ -844,6 +895,13 @@ test('search dims non-matches without moving a single card', async ({ page }) =>
   expect(lit + dimmed, 'every rendered card should be classified once a search is active')
     .toBe(after.length);
   expect(lit, 'the query should match at least one memory in this store').toBeGreaterThan(0);
+  // THE assertion this test was missing. `lit + dimmed === total` and `lit > 0`
+  // are both satisfied by lit === total, dimmed === 0 -- which is exactly what
+  // shipped: search_memories returns the whole store at min_score 0, so every
+  // card was lit and a query dimmed nothing. Without this line the feature can
+  // be completely inert and the suite stays green.
+  expect(dimmed, 'a query that matches SOME memories must dim the rest — if nothing dims, search is inert')
+    .toBeGreaterThan(0);
 
   // Clearing restores everything.
   await page.locator('#searchInput').fill('');
@@ -857,8 +915,16 @@ test('a search at the wall survives a dive and lights the districts inside', asy
   test.slow();
   await page.locator('#searchInput').fill('memory');
   await page.waitForTimeout(1200);
-  const litProjects = await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-hit').length);
-  expect(litProjects, 'at least one project should contain a match').toBeGreaterThan(0);
+  const wall = await page.evaluate(() => ({
+    lit: document.querySelectorAll('#drum .card3d.search-hit').length,
+    dim: document.querySelectorAll('#drum .card3d.search-dim').length,
+  }));
+  expect(wall.lit, 'at least one project should contain a match').toBeGreaterThan(0);
+  // Counted SEPARATELY from here down. The old version summed hits and dims,
+  // which passes just as happily when isLit returns the same answer for every
+  // card -- either all lit (what actually shipped) or all dim.
+  expect(wall.dim, 'some projects must contain no match at all — otherwise the query discriminates nothing')
+    .toBeGreaterThan(0);
 
   // Dive into the centred card, which the search left in place.
   const box = page.viewportSize()!;
@@ -866,9 +932,108 @@ test('a search at the wall survives a dive and lights the districts inside', asy
   await page.waitForTimeout(1700);
 
   expect(await page.locator('#searchInput').inputValue(), 'the query must survive the dive').toBe('memory');
-  const stillClassified = await page.evaluate(() =>
-    document.querySelectorAll('#drum .card3d.search-hit, #drum .card3d.search-dim').length);
-  expect(stillClassified, 'the deeper level should be classified by the same query').toBeGreaterThan(0);
+  const inside = await page.evaluate(() => ({
+    lit: document.querySelectorAll('#drum .card3d.search-hit').length,
+    dim: document.querySelectorAll('#drum .card3d.search-dim').length,
+    rendered: document.querySelectorAll('#drum .card3d').length,
+  }));
+  // The named property: the SAME query, re-read one level deeper, lights the
+  // districts that contain the match. isLit's district branch returning false
+  // for everything fails here; summing the two classes did not.
+  expect(inside.lit, 'the districts holding the match should light without re-typing').toBeGreaterThan(0);
+  expect(inside.lit + inside.dim, 'every card at the deeper level should be classified').toBe(inside.rendered);
+  // Deliberately no `inside.dim > 0`: a project can honestly have a match in
+  // every one of its (typically four) districts, so an all-lit district ring is
+  // a legitimate answer. The dim assertion that guards against a degenerate
+  // "everything lights" belongs at the wall above, where twenty projects give it
+  // real margin.
+});
+
+// stepBy's search branch: while a query is active, stepping goes hit-to-hit
+// rather than one card at a time. It is the largest deviation in this feature
+// from the plan's prescribed code, and it shipped untested -- and inert, because
+// with every card lit nextLitIndex just returns from + 1 and the branch is
+// indistinguishable from ordinary stepping.
+//
+// Run at the WALL, deliberately. The two viewports do not dive into the same
+// bucket (diveToMemories clicks the viewport centre, and the stage is inset by
+// the chrome and hud, which are proportionally much taller on a phone), and on
+// mobile-safari it lands in a three-card bucket -- which stepBy renders as a
+// FAN, and the fan branch returns before the search branch is ever reached. The
+// twenty-project wall is a cylinder on both engines and needs no navigation.
+test('stepping during a search lands on hits, the short way round', async ({ page }) => {
+  test.slow();
+  await settleLayout(page);
+  // Few enough projects hold a "rolodex" memory that ordinary stepping would
+  // almost certainly land in the dark -- which is the whole point. 'memory'
+  // lights most of the wall and would let plain stepping pass by luck.
+  await page.locator('#searchInput').fill('rolodex');
+  await page.waitForTimeout(1500); // 250ms debounce + daemon round trip
+
+  const read = () => page.evaluate(() => {
+    const f = document.querySelector('#drum .card3d.front');
+    const m = /card (\d+) of (\d+)/.exec(document.querySelector('#position')?.textContent ?? '');
+    return {
+      card: m ? Number(m[1]) : NaN,
+      count: m ? Number(m[2]) : NaN,
+      rotation: Number(/rotateY\(([-\d.]+)deg\)/.exec((document.querySelector('#drum') as HTMLElement).style.transform)?.[1] ?? NaN),
+      hit: !!f?.classList.contains('search-hit'),
+      dim: !!f?.classList.contains('search-dim'),
+      lit: document.querySelectorAll('#drum .card3d.search-hit').length,
+      dark: document.querySelectorAll('#drum .card3d.search-dim').length,
+    };
+  });
+
+  // A step eases toward its goal a frame at a time, so read the drum only once
+  // its transform has stopped moving; a flat wait sampled mid-ease and reported
+  // the card being left rather than the one arrived at. The generous budget is
+  // not slack: Playwright's headless WebKit throttles requestAnimationFrame hard
+  // enough that a single one-card step measured ~9 seconds to converge, against
+  // well under one on desktop Chromium.
+  const settleDrum = async () => {
+    await page.evaluate(() => { (window as any).__lastDrumTransform = null; });
+    await page.waitForFunction(() => {
+      const t = (document.querySelector('#drum') as HTMLElement).style.transform;
+      const w = window as any;
+      if (w.__lastDrumTransform === t) return true;
+      w.__lastDrumTransform = t;
+      return false;
+    }, null, { timeout: 20_000, polling: 300 });
+  };
+
+  let prev = await read();
+  expect(prev.lit, 'the query should light at least one project').toBeGreaterThan(0);
+  expect(prev.dark, 'this test is only meaningful if the query leaves some cards dark').toBeGreaterThan(0);
+
+  // Two steps, not more: with only a couple of lit projects on the wall the
+  // second already proves both halves (a long skip, then the short hop back),
+  // and every extra step costs the WebKit run another ~9 seconds.
+  const advances: number[] = [];
+  for (let step = 1; step <= 2; step++) {
+    await page.locator('#spinNext').click();
+    await settleDrum();
+    const now = await read();
+
+    expect(now.hit, `step ${step} should land on a match, not simply the next card along`).toBe(true);
+    expect(now.dim, `step ${step} must not leave a dimmed card centred`).toBe(false);
+    // The deviation this branch exists for: the goal is computed relative to the
+    // CURRENT rotation via shortestDelta, so a drum that has accumulated real
+    // turns still takes the short way to a distant hit. Handing rotationForCard's
+    // absolute small-range angle straight to stepTarget would spin whole laps.
+    expect(Number.isFinite(now.rotation), 'the drum transform should carry a readable rotation').toBe(true);
+    expect(Math.abs(now.rotation - prev.rotation),
+      `step ${step} took the long way round the drum`).toBeLessThanOrEqual(180.5);
+
+    advances.push(((now.card - prev.card) % now.count + now.count) % now.count);
+    prev = now;
+  }
+
+  // The assertion ordinary stepping cannot satisfy: at least one of those steps
+  // moved by MORE than one card, i.e. it skipped over dark ones. Without it, a
+  // wall where the hits happen to sit next to each other would pass on hits
+  // alone.
+  expect(advances.some(d => d > 1),
+    `every step advanced by exactly one card (${advances.join(', ')}) — stepping did not skip the dark cards`).toBe(true);
 });
 
 // window's contextmenu handler predates the search box and only exempted
@@ -888,4 +1053,28 @@ test('right-clicking the search input does not navigate the drum', async ({ page
   expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level),
     'a right-click in the search box must not zoom the drum out').toBe('memories');
   expect(await page.locator('#searchInput').inputValue(), 'the query must survive a right-click').toBe('memory');
+});
+
+// A failed search and a search that matched nothing both arrive as an empty hit
+// set and both render as "everything dimmed". Without a check on the response,
+// a dead daemon or a store the bridge refuses to serve looked exactly like an
+// honest miss -- silently, and with the coordinate still hidden behind the query.
+test('a failing search says so instead of looking like no matches', async ({ page }) => {
+  test.slow();
+  // Shaped like the route's real failure: HTTP 500 carrying ok:false, which is
+  // why res.ok alone would not have caught it.
+  await page.route('**/search?*', (route) => route.fulfill({
+    status: 500,
+    contentType: 'application/json',
+    body: JSON.stringify({ ok: false, error: 'daemon unreachable', query: 'memory' }),
+  }));
+
+  await page.locator('#searchInput').fill('memory');
+  await page.waitForTimeout(1200); // 250ms debounce + the round trip
+
+  await expect(page.locator('#toast')).toHaveClass(/show/);
+  expect(await page.locator('#toast').textContent()).toMatch(/search failed/i);
+  // And it must not silently classify the drum off an empty result set.
+  expect(await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-dim').length),
+    'a failed search must not dim the whole drum as though nothing matched').toBe(0);
 });

--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -1078,3 +1078,56 @@ test('a failing search says so instead of looking like no matches', async ({ pag
   expect(await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-dim').length),
     'a failed search must not dim the whole drum as though nothing matched').toBe(0);
 });
+
+// A bridge process is long-lived; the page is served fresh from disk on every
+// request. A bridge that was started before /search landed answers with
+// Express's own default 404 -- an HTML page, not our {ok, hits} contract --
+// which is a *reachable*, stale bridge, not an unreachable one. Mirrors
+// Express's real default body so the regression this pins is the one that
+// actually shipped, not a stand-in for it.
+//
+// The toast must not promise that restarting fixes it, either: a bridge that
+// fails to bind its port can linger alive instead of exiting, so a user who
+// restarts still has the same stale process answering on the port -- a real
+// field case, not a hypothetical. Point at the bridge being out of date, not
+// at an action that may not work.
+test('a stale bridge (404 on /search) says so, not "could not reach"', async ({ page }) => {
+  test.slow();
+  await page.route('**/search?*', (route) => route.fulfill({
+    status: 404,
+    contentType: 'text/html; charset=utf-8',
+    body: '<!DOCTYPE html>\n<html lang="en">\n<head><title>Error</title></head>\n<body><pre>Cannot GET /search</pre></body></html>',
+  }));
+
+  await page.locator('#searchInput').fill('memory');
+  await page.waitForTimeout(1200); // 250ms debounce + the round trip
+
+  await expect(page.locator('#toast')).toHaveClass(/show/);
+  const toastText = await page.locator('#toast').textContent();
+  expect(toastText, 'a stale bridge must name itself, not read as unreachable').not.toMatch(/could not reach/i);
+  expect(toastText, 'a 404 on /search means an old bridge process, not a dead one').toMatch(/bridge/i);
+  expect(toastText, 'a restart may not clear a bridge that lingered holding the port -- do not promise it fixes this')
+    .not.toMatch(/restart it/i);
+  expect(toastText, 'point at the bridge being out of date, since that survives a failed restart attempt')
+    .toMatch(/out of date/i);
+  // A stale-route response is not evidence the store stopped matching --
+  // the previous classification (none yet, here) must stand, not be wiped.
+  expect(await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-dim').length),
+    'a stale-bridge 404 must not dim the whole drum as though nothing matched').toBe(0);
+});
+
+// The genuinely unreachable case -- nothing answered at all -- must keep its
+// own wording rather than being folded into the stale-bridge or generic
+// failure messages now that all three are told apart.
+test('a search with no bridge listening says it could not reach it', async ({ page }) => {
+  test.slow();
+  await page.route('**/search?*', (route) => route.abort('connectionrefused'));
+
+  await page.locator('#searchInput').fill('memory');
+  await page.waitForTimeout(1200); // 250ms debounce + the round trip
+
+  await expect(page.locator('#toast')).toHaveClass(/show/);
+  expect(await page.locator('#toast').textContent()).toMatch(/could not reach the bridge/i);
+  expect(await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-dim').length),
+    'an unreachable bridge must not dim the whole drum as though nothing matched').toBe(0);
+});

--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -819,3 +819,54 @@ test("long-pressing a project card's Rename control opens rename, not create", a
   await expect(page.locator('#renameModalBg')).toHaveClass(/open/);
   await expect(page.locator('#editModalBg')).not.toHaveClass(/open/);
 });
+
+// Search DIMS rather than filtering or reordering: a 3D ring's one advantage
+// over a list is that "my card was over there" stays true.
+test('search dims non-matches without moving a single card', async ({ page }) => {
+  test.slow();
+  expect(await diveToMemories(page)).toBe('memories');
+
+  const before = await page.evaluate(() => [...document.querySelectorAll('#drum .card3d')]
+    .map(c => { const r = c.getBoundingClientRect(); return { idx: (c as HTMLElement).dataset.idx, x: Math.round(r.x), y: Math.round(r.y) }; }));
+
+  // Query a word certain to appear in this store's own memories.
+  await page.locator('#searchInput').fill('memory');
+  await page.waitForTimeout(1200); // 250ms debounce + daemon round trip
+
+  const after = await page.evaluate(() => [...document.querySelectorAll('#drum .card3d')]
+    .map(c => { const r = c.getBoundingClientRect(); return { idx: (c as HTMLElement).dataset.idx, x: Math.round(r.x), y: Math.round(r.y) }; }));
+  expect(after, 'search must not move any card').toEqual(before);
+
+  const dimmed = await page.evaluate(() =>
+    document.querySelectorAll('#drum .card3d.search-dim').length);
+  const lit = await page.evaluate(() =>
+    document.querySelectorAll('#drum .card3d.search-hit').length);
+  expect(lit + dimmed, 'every rendered card should be classified once a search is active')
+    .toBe(after.length);
+  expect(lit, 'the query should match at least one memory in this store').toBeGreaterThan(0);
+
+  // Clearing restores everything.
+  await page.locator('#searchInput').fill('');
+  await page.waitForTimeout(600);
+  expect(await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-dim').length)).toBe(0);
+});
+
+// The same query means something at every depth: one call, held once,
+// re-interpreted one level deeper each time you dive.
+test('a search at the wall survives a dive and lights the districts inside', async ({ page }) => {
+  test.slow();
+  await page.locator('#searchInput').fill('memory');
+  await page.waitForTimeout(1200);
+  const litProjects = await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-hit').length);
+  expect(litProjects, 'at least one project should contain a match').toBeGreaterThan(0);
+
+  // Dive into the centred card, which the search left in place.
+  const box = page.viewportSize()!;
+  await page.mouse.click(box.width / 2, box.height / 2);
+  await page.waitForTimeout(1700);
+
+  expect(await page.locator('#searchInput').inputValue(), 'the query must survive the dive').toBe('memory');
+  const stillClassified = await page.evaluate(() =>
+    document.querySelectorAll('#drum .card3d.search-hit, #drum .card3d.search-dim').length);
+  expect(stillClassified, 'the deeper level should be classified by the same query').toBeGreaterThan(0);
+});

--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -790,3 +790,32 @@ test('long-pressing a district card creates with project and district pre-filled
   // suppressed, so we are still at districts.
   expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level)).toBe('districts');
 });
+
+// A slow, deliberate click on a real control is still an ordinary click -- the
+// long-press gesture must not steal it. Rename… lives on the project card
+// (the wall level), the one control that sits inside a create-eligible level.
+test("long-pressing a project card's Rename control opens rename, not create", async ({ page }) => {
+  test.slow();
+  // Already at the wall (projects level) on load. settleLayout first: the
+  // debounced buildDrum rebuild (see its own comment above) can still be
+  // in flight right after load, and measuring the button's rect mid-settle
+  // is exactly the trap that comment warns about -- the press would land
+  // on wherever the card was BEFORE the rebuild finished, not the button.
+  await settleLayout(page);
+  const renameBtn = await page.evaluate(() => {
+    const btn = document.querySelector('#drum .card3d.front [data-rename]') as HTMLElement | null;
+    if (!btn) return null;
+    const r = btn.getBoundingClientRect();
+    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+  });
+  expect(renameBtn, 'the front project card should have a Rename control to press').not.toBeNull();
+
+  await page.mouse.move(renameBtn!.x, renameBtn!.y);
+  await page.mouse.down();
+  await page.waitForTimeout(750); // past LONG_PRESS_MS
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+
+  await expect(page.locator('#renameModalBg')).toHaveClass(/open/);
+  await expect(page.locator('#editModalBg')).not.toHaveClass(/open/);
+});

--- a/scripts/nd-mem-bridge-server.mjs
+++ b/scripts/nd-mem-bridge-server.mjs
@@ -121,7 +121,7 @@ app.get('/search', async (req, res) => {
     if (req.query.project_id) args.project_id = String(req.query.project_id);
     // Number('abc') is NaN, which serialises to null and reaches the tool as a
     // malformed argument; an unparseable threshold means "no threshold given".
-    if (req.query.min_score) {
+    if (req.query.min_score !== undefined && req.query.min_score !== '') {
       const minScore = Number(req.query.min_score);
       if (Number.isFinite(minScore)) args.min_score = minScore;
     }

--- a/scripts/nd-mem-bridge-server.mjs
+++ b/scripts/nd-mem-bridge-server.mjs
@@ -8,6 +8,7 @@ import { execFile } from 'child_process';
 import * as readline from 'readline';
 import { ensureDaemon } from '../build/core/ensure-daemon.js';
 import { resolveDaemonPort } from '../build/core/run-mode.js';
+import { parseSearchResults } from './nd-mem-rolodex-helpers.mjs';
 
 // Resolved from this file's own location, not process.cwd() — the bridge must
 // find its assets the same way regardless of the directory it's launched from.
@@ -88,6 +89,29 @@ setInterval(pollForChanges, POLL_MS);
 
 app.get('/health', (_req, res) => res.json({ ok: true, port: PORT, memoryPath: MEMORY_PATH, pollMs: POLL_MS }));
 app.get('/memories', (_req, res) => { try { res.json(readSnapshot()); } catch (error) { res.status(500).json({ error: String(error), path: MEMORY_PATH }); } });
+
+// READ ONLY. Ranks through the daemon so the UI sees exactly what an agent
+// would -- same BM25, same tie-breaks -- rather than a second, divergent
+// client-side filter. Only the id and score are parsed out of the tool's prose;
+// everything else the UI needs it already has in the snapshot.
+app.get('/search', async (req, res) => {
+  const query = String(req.query.q ?? '').trim();
+  if (!query) { res.json({ ok: true, query: '', total: 0, hits: [] }); return; }
+  try {
+    const args = { query };
+    if (req.query.district) args.district = String(req.query.district);
+    if (req.query.project_id) args.project_id = String(req.query.project_id);
+    if (req.query.min_score) args.min_score = Number(req.query.min_score);
+    if (req.query.tags) args.tags = String(req.query.tags).split(',').map(s => s.trim()).filter(Boolean);
+
+    const { result } = await runMcpTool('search_memories', args);
+    const text = result?.result?.content?.map(c => c?.text).filter(Boolean).join('\n') ?? '';
+    const hits = parseSearchResults(text);
+    res.json({ ok: true, query, total: hits.length, hits });
+  } catch (error) {
+    res.status(500).json({ ok: false, error: String(error), query });
+  }
+});
 app.get('/events', (req, res) => {
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',

--- a/scripts/nd-mem-bridge-server.mjs
+++ b/scripts/nd-mem-bridge-server.mjs
@@ -94,6 +94,24 @@ app.get('/memories', (_req, res) => { try { res.json(readSnapshot()); } catch (e
 // would -- same BM25, same tie-breaks -- rather than a second, divergent
 // client-side filter. Only the id and score are parsed out of the tool's prose;
 // everything else the UI needs it already has in the snapshot.
+//
+// SEARCH_MEMORIES RETURNS THE WHOLE STORE. Its min_score defaults to 0, and
+// BM25 scores a document containing none of the query terms exactly 0 (every
+// term hits a `continue`, and the Robertson IDF variant it uses is always
+// positive, so a score is never negative). `0 >= 0` passes the threshold, and
+// there is no result cap anywhere in the tool -- so an unfiltered response ranks
+// the one real match first and then lists every other memory at 0.000. The
+// rolodex dims misses instead of filtering them, which meant EVERY card was lit
+// and search discriminated nothing. Dropping the zeroes is the whole feature.
+//
+// Filtered here rather than by passing a small epsilon as min_score: the tool's
+// schema documents `minimum: 0`, so an epsilon would be quietly outside the
+// contract, and this is the only place the reason can be written down. The one
+// cost is honest and tiny -- scores arrive through prose at three decimals, so a
+// genuine match normalising below 0.0005 of the top hit reads as 0.000 and is
+// dropped with the non-matches. That takes a single very common query term plus
+// an extreme document-length spread, and a card missing from the lit set is a
+// far smaller failure than every card being in it.
 app.get('/search', async (req, res) => {
   const query = String(req.query.q ?? '').trim();
   if (!query) { res.json({ ok: true, query: '', total: 0, hits: [] }); return; }
@@ -101,12 +119,19 @@ app.get('/search', async (req, res) => {
     const args = { query };
     if (req.query.district) args.district = String(req.query.district);
     if (req.query.project_id) args.project_id = String(req.query.project_id);
-    if (req.query.min_score) args.min_score = Number(req.query.min_score);
+    // Number('abc') is NaN, which serialises to null and reaches the tool as a
+    // malformed argument; an unparseable threshold means "no threshold given".
+    if (req.query.min_score) {
+      const minScore = Number(req.query.min_score);
+      if (Number.isFinite(minScore)) args.min_score = minScore;
+    }
     if (req.query.tags) args.tags = String(req.query.tags).split(',').map(s => s.trim()).filter(Boolean);
 
     const { result } = await runMcpTool('search_memories', args);
     const text = result?.result?.content?.map(c => c?.text).filter(Boolean).join('\n') ?? '';
-    const hits = parseSearchResults(text);
+    // See the block comment above: score 0 means "matched none of the query
+    // terms", not "matched weakly". total counts what actually survives.
+    const hits = parseSearchResults(text).filter(h => h.score > 0);
     res.json({ ok: true, query, total: hits.length, hits });
   } catch (error) {
     res.status(500).json({ ok: false, error: String(error), query });

--- a/scripts/nd-mem-rolodex-helpers.mjs
+++ b/scripts/nd-mem-rolodex-helpers.mjs
@@ -660,3 +660,31 @@ export function hintFor(level, pointerKind) {
   const table = HINTS[pointerKind] ?? HINTS.fine;
   return table[level] ?? table.default;
 }
+
+// search_memories answers in PROSE, for a reader:
+//   • [0.873] memory_123 — Some title (scholar)
+//     first eighty characters of content…
+// There is no structured search API and the BM25 index is private to
+// server-main.ts, so the bridge recovers the two tokens it cannot get locally --
+// the id and its score -- and hydrates everything else from the snapshot it
+// already reads. Deliberately anchored on the "[score] id" shape: the partial-
+// matches block below the results uses bullets too, but carries no score, so
+// requiring the bracket keeps those out.
+//
+// This regex is the whole fragile seam in the search feature. Its failure mode
+// is SILENT -- zero hits, not an error -- which is why a contract test runs the
+// real tool and asserts this still parses it.
+const SEARCH_HIT_RE = /^\s*[•*-]\s*\[(\d+(?:\.\d+)?)\]\s*(\S+)\s+—/;
+
+export function parseSearchResults(text) {
+  if (typeof text !== 'string' || text === '') return [];
+  const hits = [];
+  for (const line of text.split('\n')) {
+    const m = SEARCH_HIT_RE.exec(line);
+    if (!m) continue;
+    const score = Number(m[1]);
+    if (!Number.isFinite(score)) continue;
+    hits.push({ id: m[2], score });
+  }
+  return hits;
+}

--- a/scripts/nd-mem-rolodex-helpers.mjs
+++ b/scripts/nd-mem-rolodex-helpers.mjs
@@ -540,6 +540,31 @@ export function truncateNodeLabel(label, max = NODE_LABEL_MAX) {
   return `${s.slice(0, head)}…${tail ? s.slice(-tail) : ''}`;
 }
 
+// What a new memory inherits from where you are standing. The deeper you are,
+// the more context it takes -- which is exactly what the coordinate already
+// means. A long-pressed card outranks the current view, because pressing a
+// specific card is a more explicit statement of intent than standing near it.
+//
+// UNASSIGNED is a DISPLAY bucket for memories with no project, not a project
+// id. Inheriting it would create a real project literally named '(no project)'.
+export function createDefaultsFor(view, pressedCard = null) {
+  const realProject = (id) => (id && id !== UNASSIGNED ? String(id) : null);
+
+  if (pressedCard && pressedCard.kind === 'project') {
+    return { projectId: realProject(pressedCard.id), district: null };
+  }
+  if (pressedCard && pressedCard.kind === 'district') {
+    return { projectId: realProject(view.projectId), district: String(pressedCard.id) };
+  }
+  if (view.level === 'memories') {
+    return { projectId: realProject(view.projectId), district: view.districtId ? String(view.districtId) : null };
+  }
+  if (view.level === 'districts') {
+    return { projectId: realProject(view.projectId), district: null };
+  }
+  return { projectId: null, district: null };
+}
+
 // Columns are deliberately much wider than a node (r=5, so 10px across): at 26px a
 // fork read as a jog in a trunk rather than a branch. Rows are tighter than columns
 // so a deep chain does not stretch the tree into a thread.

--- a/scripts/nd-mem-rolodex-helpers.mjs
+++ b/scripts/nd-mem-rolodex-helpers.mjs
@@ -572,6 +572,22 @@ export function createDefaultsFor(view, pressedCard = null) {
   return { projectId: null, district: null };
 }
 
+// What the edit modal's district <select> should be populated with, so that
+// assigning `district` to it always finds an <option>.
+//
+// register_district is a supported tool and deriveDistricts renders a card for
+// whatever district the data actually contains, so a legacy or custom district
+// reaches the modal routinely -- and a <select> asked for a value it has no
+// option for silently goes to selectedIndex -1, i.e. renders BLANK. Edit mode
+// prepended the stray value; create mode did not, so long-pressing a custom
+// district card opened a modal with an empty District field and then posted
+// district: ''. One function now, because the defect was precisely that the
+// rule lived in one of the two places that needed it.
+export function districtOptions(district) {
+  if (!district || CANONICAL_DISTRICTS.includes(district)) return CANONICAL_DISTRICTS;
+  return [district, ...CANONICAL_DISTRICTS];
+}
+
 // Columns are deliberately much wider than a node (r=5, so 10px across): at 26px a
 // fork read as a jog in a trunk rather than a branch. Rows are tighter than columns
 // so a deep chain does not stretch the tree into a thread.

--- a/scripts/nd-mem-rolodex-helpers.mjs
+++ b/scripts/nd-mem-rolodex-helpers.mjs
@@ -545,19 +545,21 @@ export function truncateNodeLabel(label, max = NODE_LABEL_MAX) {
 // means. A long-pressed card outranks the current view, because pressing a
 // specific card is a more explicit statement of intent than standing near it.
 //
-// UNASSIGNED is a DISPLAY bucket for memories with no project, not a project
-// id. Inheriting it would create a real project literally named '(no project)'.
+// UNASSIGNED and UNCATEGORIZED are DISPLAY buckets for memories with no project
+// or district respectively, not real project/district ids. Inheriting them would
+// create literal entities named after the placeholders, which is wrong.
 export function createDefaultsFor(view, pressedCard = null) {
   const realProject = (id) => (id && id !== UNASSIGNED ? String(id) : null);
+  const realDistrict = (id) => (id && id !== UNCATEGORIZED ? String(id) : null);
 
   if (pressedCard && pressedCard.kind === 'project') {
     return { projectId: realProject(pressedCard.id), district: null };
   }
   if (pressedCard && pressedCard.kind === 'district') {
-    return { projectId: realProject(view.projectId), district: String(pressedCard.id) };
+    return { projectId: realProject(view.projectId), district: realDistrict(pressedCard.id) };
   }
   if (view.level === 'memories') {
-    return { projectId: realProject(view.projectId), district: view.districtId ? String(view.districtId) : null };
+    return { projectId: realProject(view.projectId), district: realDistrict(view.districtId) };
   }
   if (view.level === 'districts') {
     return { projectId: realProject(view.projectId), district: null };

--- a/scripts/nd-mem-rolodex-helpers.mjs
+++ b/scripts/nd-mem-rolodex-helpers.mjs
@@ -329,6 +329,11 @@ export function routeGesture(kind, ctx) {
     case 'clickOther': return 'centerThenDive';
     case 'arrowLeft': return 'stepPrev';
     case 'arrowRight': return 'stepNext';
+    // Long-press creates, carrying the pressed card's context. Not at the
+    // memories level: there the card is a reading surface and the press belongs
+    // to text selection. Right-click is unavailable -- `rightClick` above
+    // already means zoomOut -- so this is the only free gesture.
+    case 'longPress': return level === 'memories' ? 'none' : 'create';
     default: return 'none';
   }
 }

--- a/scripts/nd-mem-rolodex-helpers.mjs
+++ b/scripts/nd-mem-rolodex-helpers.mjs
@@ -688,3 +688,46 @@ export function parseSearchResults(text) {
   }
   return hits;
 }
+
+// ---------- search lighting ----------
+
+// One rule at every level: a card is lit if IT, or anything inside it, matched.
+// That is what turns a search into a drill-down -- query at the wall, see which
+// projects light, dive into a lit one, see which districts light -- instead of
+// needing a separate results view.
+export function isLit(item, hits, snapshot, view = {}) {
+  if (!hits || hits.size === 0 || !item) return false;
+  if (item.kind === 'memory') return hits.has(item.id);
+  const memories = Object.values(snapshot?.memories ?? {});
+  if (item.kind === 'project') {
+    return memories.some(m => hits.has(m.id) && projectOf(m) === item.id);
+  }
+  if (item.kind === 'district') {
+    // Scoped to the project being viewed. District names are shared across
+    // projects, not globally unique buckets -- without this, standing inside
+    // project beta would light its practical_execution card because something
+    // in ALPHA's practical_execution matched.
+    const scope = view.projectId;
+    return memories.some(m => hits.has(m.id)
+      && districtOf(m) === item.id
+      && (scope == null || projectOf(m) === scope));
+  }
+  return false;
+}
+
+// Stepping skips dark cards while a search is active, so a 364-memory bucket
+// stays fast. With nothing lit at this level, fall back to ordinary stepping
+// rather than refusing to move -- a search that matches nothing here must not
+// strand the drum.
+export function nextLitIndex(items, hits, snapshot, view, from, direction) {
+  const count = items.length;
+  if (!count) return from;
+  const step = direction >= 0 ? 1 : -1;
+  const plain = ((from + step) % count + count) % count;
+  if (!hits || hits.size === 0) return plain;
+  for (let i = 1; i <= count; i++) {
+    const idx = ((from + step * i) % count + count) % count;
+    if (isLit(items[idx], hits, snapshot, view)) return idx;
+  }
+  return plain;
+}

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -66,21 +66,34 @@
     #crumb .seg:disabled:hover{background:none}
     #crumb .sep{color:var(--faint);padding:0 1px}
     #position{flex:0 0 auto;font-size:.78rem;color:var(--muted);white-space:nowrap}
-    /* Shares the band's row. While a query is active the coordinate hides: the
-       coordinate answers "where am I", the query answers "what am I looking
-       for", and both are rarely needed at once. The row already wraps at every
-       width and is already guarded at five viewports. */
+    /* Shares the band's row, sized to match the surrounding pills. The
+       coordinate (#crumb) does NOT free any space when a query is active --
+       see #locus.searching below, which keeps its box on purpose -- so this
+       is purely "one more thing sharing the row", not "the row grows". */
     #searchInput{flex:1 1 12rem;min-width:0;padding:4px 10px;border-radius:999px;
       border:1px solid var(--surfaceBorder);background:var(--wash);color:var(--text);
-      font:inherit;font-size:.82rem}
+      font:inherit;font-size:.82rem;user-select:text}
     #searchInput::placeholder{color:var(--faint)}
-    /* visibility, not display:none: #crumb wraps to two lines at real
-       coordinate depths on a narrow viewport (see the #chrome comment above),
-       so REMOVING it from flow shrinks #locus, which shrinks the measured
-       --chromeH #stage insets by, which moves every card up the moment a
-       query starts -- caught by the "search must not move a single card"
-       test on mobile-safari at the memories depth. Keeping its box (just
-       painted transparent) holds #chrome's height steady either way. */
+    /* 16px, not the .82rem (~13px) above, on a coarse (touch) pointer only:
+       below 16px, iOS Safari zooms the visual viewport on focus, which would
+       visibly move every card -- the exact invariant this feature exists to
+       defend, and one Playwright's WebKit cannot reproduce (no CDP, so this
+       needed reasoning from the platform behaviour, not a failing test).
+       Scoped to touch rather than applied everywhere: a mouse pointer never
+       triggers that zoom, so the desktop band keeps its tighter, pill-matching
+       size instead of an oversized input nobody there needs. */
+    @media (pointer: coarse){
+      #searchInput{font-size:16px}
+    }
+    /* visibility, not display:none, when a query is active: #crumb wraps to
+       two lines at real coordinate depths on a narrow viewport (see the
+       #chrome comment above), so REMOVING it from flow would shrink #locus,
+       which would shrink the measured --chromeH #stage insets by, moving
+       every card up the instant a query starts -- caught by the "search must
+       not move a single card" test on mobile-safari at the memories depth.
+       Keeping its box (just painted transparent) holds #chrome's height
+       steady either way; nothing here frees up room for #searchInput, which
+       is sized independently above. */
     #locus.searching #crumb{visibility:hidden}
     /* Inset below the chrome rather than sitting under it. #chrome is fixed, so
        for as long as #stage started at the viewport top the bar simply COVERED
@@ -1703,6 +1716,13 @@
       if (action === 'dive' || action === 'centerThenDive') dive();
     });
     window.addEventListener('contextmenu', (e) => {
+      // Every text field keeps its native menu, not just the ones inside a
+      // modal -- #searchInput lives on the chrome bar itself, outside any
+      // modal, and without this a right-click (or an iOS long-press) on it
+      // suppressed the menu AND navigated the drum up a level mid-query.
+      // Same guard shape as the keydown handler below.
+      const t = e.target instanceof Element ? e.target : null;
+      if (t && t.closest('input, textarea, select')) return;
       if (document.querySelector('.modalbg.open')) return; // modal text fields keep the native menu
       e.preventDefault();
       if (!state.transitioning) zoomOut();

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -1795,23 +1795,51 @@
     async function runSearch(query){
       const seq = ++searchSeq;
       if (!query) { state.search = { query: '', hits: new Map() }; renderSearchState(); return; }
+      // A failed search and a search that matched nothing both arrive as an
+      // empty hit set, and both would render as "every card dimmed" if we let
+      // them -- so a dead daemon, a stale bridge, or a store that refuses to
+      // serve all need to say so instead of looking like an honest miss.
+      // res.ok/status is checked *before* the body is ever parsed, because the
+      // three failures below are told apart by how the response failed, not by
+      // what (if anything) is inside it:
+      //   1. the fetch itself threw -- nothing answered on that port at all.
+      //   2. HTTP 404 -- the bridge answered, but has no /search route. This
+      //      process is long-lived while the page is served fresh each load,
+      //      so in practice this means the bridge predates the page and is
+      //      running stale code. Do not promise a restart fixes it: a bridge
+      //      that fails to bind its port can linger alive instead of exiting,
+      //      so a plain restart can leave the same stale process answering --
+      //      point at the bridge's version being wrong, not at a fix.
+      //   3. any other non-ok status, or a 2xx response whose body isn't the
+      //      {ok, hits} contract our own route promises (including a body
+      //      that fails to parse as JSON at all) -- the bridge is current and
+      //      reachable but the search itself failed.
+      // Every branch below leaves the previous hit classification standing
+      // rather than clearing it: an error is not evidence the store stopped
+      // matching, and wiping the drum to "unclassified" would look exactly
+      // like no search being active, silently undoing the point of the toast.
+      let res;
       try {
-        const res = await fetch(`${BRIDGE}/search?q=${encodeURIComponent(query)}`);
-        const data = await res.json();
-        if (seq !== searchSeq) return; // superseded
-        // A failed search and a search that matched nothing both arrive as an
-        // empty hit set, and both render as "every card dimmed" -- so without
-        // this check a 500 (a dead daemon, a store the bridge refuses to serve)
-        // is indistinguishable from an honest miss, silently and with no toast.
-        // The route answers ok:false with a JSON body on failure, so res.ok
-        // alone is not enough.
-        if (!res.ok || !data.ok) { showToast('Search failed — the drum is unchanged.'); return; }
-        state.search = { query, hits: new Map((data.hits || []).map(h => [h.id, h.score])) };
+        res = await fetch(`${BRIDGE}/search?q=${encodeURIComponent(query)}`);
       } catch {
-        if (seq !== searchSeq) return;
-        state.search = { query, hits: new Map() };
+        if (seq !== searchSeq) return; // superseded
         showToast('Search could not reach the bridge.');
+        return;
       }
+      if (seq !== searchSeq) return; // superseded
+      if (res.status === 404) { showToast('Search needs a newer bridge — the one answering is out of date.'); return; }
+      if (!res.ok) { showToast('Search failed — the drum is unchanged.'); return; }
+      let data;
+      try {
+        data = await res.json();
+      } catch {
+        if (seq !== searchSeq) return; // superseded
+        showToast('Search failed — the drum is unchanged.');
+        return;
+      }
+      if (seq !== searchSeq) return; // superseded
+      if (!data.ok) { showToast('Search failed — the drum is unchanged.'); return; }
+      state.search = { query, hits: new Map((data.hits || []).map(h => [h.id, h.score])) };
       renderSearchState();
     }
     els.searchInput.addEventListener('input', () => {

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -171,7 +171,14 @@
        .reader-scroll, whose user-select:text is deliberate and is how a memory
        is read and copied. */
     #stage:not([data-level="memories"]) .card3d{-webkit-touch-callout:none}
-    @media (hover:hover){.card3d:not(.front):hover{opacity:.75}}
+    /* :not(.search-dim) rather than a specificity fight. This rule is two
+       classes plus a pseudo-class and would beat .card3d.search-dim outright,
+       so hovering a miss used to un-dim it -- and hovering is exactly what a
+       mouse does while scanning the ring for the lit cards, which made the
+       answer disappear at the moment it was being read. Search dims; hover
+       feedback keeps every card the query did not already answer "no" for, and
+       a dimmed card is still cursor:pointer and still clickable. */
+    @media (hover:hover){.card3d:not(.front):not(.search-dim):hover{opacity:.75}}
     .card3d .kicker{font-size:.7rem;text-transform:uppercase;letter-spacing:.1em;color:var(--faint)}
     .card3d h2{font-family:var(--font-display);font-size:1.15rem;line-height:1.2}
     .card3d p{color:var(--muted);line-height:1.5;font-size:.9rem;overflow:hidden}
@@ -398,7 +405,7 @@
       <button class="pill" id="themeBtn" title="Toggle theme">◐</button>
       <a class="pill" href="/">Classic view</a>
     </div>
-    <div id="locus"><input id="searchInput" type="search" placeholder="Search memories…" autocomplete="off" spellcheck="false" /><span id="crumb"></span><span id="position">—</span></div>
+    <div id="locus"><input id="searchInput" type="search" aria-label="Search memories" placeholder="Search memories…" autocomplete="off" spellcheck="false" /><span id="crumb"></span><span id="position">—</span></div>
   </div>
   <div id="stage" data-level="projects"><div id="scene"><div id="drum"></div></div></div>
   <div id="spin">
@@ -1338,7 +1345,15 @@
         // unrelated side card's div instead (see frontControlAt's comment),
         // which makes pressTarget alone unreliable for exactly this check.
         const onControl = !!pressTarget?.closest('button, a') || !!frontControlAt(e.clientX, e.clientY);
-        if (pointers.size === 1 && !onControl && H.routeGesture('longPress', { level: state.view.level, insideReader: false }) === 'create') {
+        // Not while a dive/zoom is in flight. The gesture arms on the level read
+        // HERE but resolves the pressed card 500ms later, and transitionTo flips
+        // state.view a third of the way through its ~1400ms run (ZOOM_MS = 700).
+        // A press begun 200-700ms into a dive therefore armed at `districts` and
+        // fired at `memories` -- opening a create modal at exactly the level
+        // routeGesture exists to forbid it at. Every other gesture path on this
+        // page is already gated on this flag.
+        if (pointers.size === 1 && !onControl && !state.transitioning
+            && H.routeGesture('longPress', { level: state.view.level, insideReader: false }) === 'create') {
           const px = e.clientX, py = e.clientY;
           longPressTimer = setTimeout(() => {
             longPressTimer = null;
@@ -1784,6 +1799,13 @@
         const res = await fetch(`${BRIDGE}/search?q=${encodeURIComponent(query)}`);
         const data = await res.json();
         if (seq !== searchSeq) return; // superseded
+        // A failed search and a search that matched nothing both arrive as an
+        // empty hit set, and both render as "every card dimmed" -- so without
+        // this check a 500 (a dead daemon, a store the bridge refuses to serve)
+        // is indistinguishable from an honest miss, silently and with no toast.
+        // The route answers ok:false with a JSON body on failure, so res.ok
+        // alone is not enough.
+        if (!res.ok || !data.ok) { showToast('Search failed — the drum is unchanged.'); return; }
         state.search = { query, hits: new Map((data.hits || []).map(h => [h.id, h.score])) };
       } catch {
         if (seq !== searchSeq) return;
@@ -1814,7 +1836,6 @@
     });
 
     // ---------- edit modal ----------
-    const CANONICAL = H.CANONICAL_DISTRICTS;
     // One modal, two modes. A second modal would drift from this one exactly as
     // the classic app's copy already drifted from it -- that divergence was a
     // code-review finding, not a hypothetical.
@@ -1824,7 +1845,13 @@
       state.editingId = null;
       $('#editModalTitle').textContent = 'New memory';
       $('#editSaveBtn').textContent = 'Create';
-      $('#editDistrict').innerHTML = CANONICAL.map(d => `<option value="${esc(d)}">${esc(d)}</option>`).join('');
+      // Through the same helper openEditModal uses. Populated from the canonical
+      // five alone, the assignment below found no matching <option> for a custom or
+      // legacy district, left the select at selectedIndex -1, and the user saw
+      // an EMPTY District field -- and because create mode always sends the
+      // select's value, it then posted district: ''. (Distinct from the
+      // UNCATEGORIZED sentinel, which createDefaultsFor resolves to null first.)
+      $('#editDistrict').innerHTML = H.districtOptions(defaults.district).map(d => `<option value="${esc(d)}">${esc(d)}</option>`).join('');
       $('#editContent').value = '';
       $('#editDistrict').value = defaults.district || 'practical_execution';
       // Seeded the same way openEditModal does, so submitEdit's "only send a
@@ -1843,8 +1870,7 @@
       state.modalMode = 'edit';
       $('#editModalTitle').textContent = 'Edit memory';
       $('#editSaveBtn').textContent = 'Save changes';
-      const districts = CANONICAL.includes(m.district) || !m.district ? CANONICAL : [m.district, ...CANONICAL];
-      $('#editDistrict').innerHTML = districts.map(d => `<option value="${esc(d)}">${esc(d)}</option>`).join('');
+      $('#editDistrict').innerHTML = H.districtOptions(m.district).map(d => `<option value="${esc(d)}">${esc(d)}</option>`).join('');
       $('#editContent').value = m.content || '';
       $('#editDistrict').value = m.district || 'practical_execution';
       $('#editProject').value = m.project_id ?? '';

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -1635,8 +1635,7 @@
       state.editingId = null;
       $('#editModalTitle').textContent = 'New memory';
       $('#editSaveBtn').textContent = 'Create';
-      const districts = H.CANONICAL_DISTRICTS;
-      $('#editDistrict').innerHTML = districts.map(d => `<option value="${esc(d)}">${esc(d)}</option>`).join('');
+      $('#editDistrict').innerHTML = CANONICAL.map(d => `<option value="${esc(d)}">${esc(d)}</option>`).join('');
       $('#editContent').value = '';
       $('#editDistrict').value = defaults.district || 'practical_execution';
       // Seeded the same way openEditModal does, so submitEdit's "only send a
@@ -1706,26 +1705,48 @@
       if (epistemic) body.epistemicStatus = epistemic;
 
       const route = creating ? '/save' : '/update';
-      let res, data;
-      try {
-        res = await fetch(`${BRIDGE}${route}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-        data = await res.json();
-      } catch {
-        showToast('Could not reach the bridge — nothing was saved.');
+
+      // Create and edit deliberately diverge below this point. Edit mode keeps
+      // its pre-existing shape byte-for-byte (single combined failure message,
+      // no catch-vs-rejection distinction) so an in-flight, unsaved edit still
+      // gets the "the modal is untouched, fix and retry" reassurance it always
+      // has. Create mode has no pre-existing behaviour to preserve, so it tells
+      // network failure and a rejected create apart instead.
+      if (creating) {
+        let res, data;
+        try {
+          res = await fetch(`${BRIDGE}${route}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+          data = await res.json();
+        } catch {
+          showToast('Could not reach the bridge — nothing was saved.');
+          return;
+        }
+        if (!res.ok || !data.ok) { showToast('Create failed.'); return; }
+        $('#editModalBg').classList.remove('open');
+        showToast('Memory created.');
+        // See the matching comment in the edit branch below for why this runs
+        // last and why its own failure is swallowed.
+        try { await loadSnapshot(); refreshAndReconcile(); } catch {}
         return;
       }
-      if (!res.ok || !data.ok) { showToast(creating ? 'Create failed.' : 'Update failed.'); return; }
-      $('#editModalBg').classList.remove('open');
-      showToast(creating ? 'Memory created.' : 'Memory updated.');
-      // The snapshot is otherwise only fetched at init, so both the card and a
-      // reopened modal would keep showing pre-edit values — and a second edit of
-      // the same memory would re-POST that stale content, silently reverting the
-      // first. This runs last so a reconcile toast ("centered card was removed",
-      // "this view emptied") lands after the success toast and survives, instead
-      // of being overwritten by it. Refresh failure is caught separately: the
-      // save already succeeded, so a stale card is acceptable but a stuck modal
-      // (or a false failure toast from the outer catch) is not.
-      try { await loadSnapshot(); refreshAndReconcile(); } catch {}
+      try {
+        const res = await fetch(`${BRIDGE}${route}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+        const data = await res.json();
+        if (!res.ok || !data.ok) throw new Error('update failed');
+        $('#editModalBg').classList.remove('open');
+        showToast('Update routed through the bridge.');
+        // The snapshot is otherwise only fetched at init, so both the card and a
+        // reopened modal would keep showing pre-edit values — and a second edit of
+        // the same memory would re-POST that stale content, silently reverting the
+        // first. This runs last so a reconcile toast ("centered card was removed",
+        // "this view emptied") lands after the success toast and survives, instead
+        // of being overwritten by it. Refresh failure is caught separately: the
+        // save already succeeded, so a stale card is acceptable but a stuck modal
+        // (or a false failure toast from the outer catch) is not.
+        try { await loadSnapshot(); refreshAndReconcile(); } catch {}
+      } catch {
+        showToast('Update failed — the modal is untouched, fix and retry.');
+      }
     }
 
     // ---------- project rename ----------

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -350,6 +350,7 @@
     </div>
     <div class="cluster">
       <span class="pill" id="connState">Connecting…</span>
+      <button class="pill" id="createBtn" title="New memory" aria-label="New memory">+</button>
       <button class="pill" id="helpBtn" title="What is this?" aria-label="What is this?">?</button>
       <button class="pill" id="themeBtn" title="Toggle theme">◐</button>
       <a class="pill" href="/">Classic view</a>
@@ -366,7 +367,7 @@
   <div id="overlay"><div class="box"><h2>Bridge offline</h2><p id="overlayMsg">Could not reach the bridge. Start it with <code>node scripts/nd-mem-bridge-server.mjs</code> and retry.</p><button class="btn primary" id="retryBtn">Retry</button></div></div>
   <div class="modalbg" id="editModalBg">
     <div class="modal">
-      <h2>Edit memory</h2>
+      <h2 id="editModalTitle">Edit memory</h2>
       <div class="grid">
         <div class="field span2"><label>Content</label><textarea id="editContent"></textarea></div>
         <div class="field"><label>District</label><select id="editDistrict"></select></div>
@@ -415,7 +416,7 @@
     const NODE_LABEL_PX = 58; // 10 monospace chars at .6rem; see truncateNodeLabel
 
     const $ = s => document.querySelector(s);
-    const els = { stage: $('#stage'), scene: $('#scene'), drum: $('#drum'), crumb: $('#crumb'), position: $('#position'), connState: $('#connState'), backBtn: $('#backBtn'), overlay: $('#overlay'), overlayMsg: $('#overlayMsg'), retryBtn: $('#retryBtn'), toast: $('#toast'), hudHint: $('#hudHint'), minimap: $('#minimap'), mapBody: $('#mapBody'), mapToggle: $('#mapToggle'), spin: $('#spin'), spinPrev: $('#spinPrev'), spinNext: $('#spinNext'), helpBtn: $('#helpBtn'), helpModalBg: $('#helpModalBg') };
+    const els = { stage: $('#stage'), scene: $('#scene'), drum: $('#drum'), crumb: $('#crumb'), position: $('#position'), connState: $('#connState'), backBtn: $('#backBtn'), overlay: $('#overlay'), overlayMsg: $('#overlayMsg'), retryBtn: $('#retryBtn'), toast: $('#toast'), hudHint: $('#hudHint'), minimap: $('#minimap'), mapBody: $('#mapBody'), mapToggle: $('#mapToggle'), spin: $('#spin'), spinPrev: $('#spinPrev'), spinNext: $('#spinNext'), helpBtn: $('#helpBtn'), helpModalBg: $('#helpModalBg'), createBtn: $('#createBtn') };
 
     // Three hand-tuned offsets (64/108/56) each encoded a guess at how tall
     // #chrome renders at that breakpoint. The band would have needed a fourth.
@@ -458,6 +459,7 @@
       lastBounceAt: 0,
       editingId: null,
       editingDistrict: null, // district the edit modal was seeded with, to detect a real change
+      modalMode: null,       // 'edit' or 'create' -- which mode the edit modal is currently wearing
       renamingProject: null,
     };
 
@@ -1624,8 +1626,35 @@
 
     // ---------- edit modal ----------
     const CANONICAL = H.CANONICAL_DISTRICTS;
+    // One modal, two modes. A second modal would drift from this one exactly as
+    // the classic app's copy already drifted from it -- that divergence was a
+    // code-review finding, not a hypothetical.
+    function openCreateModal(pressedCard = null){
+      const defaults = H.createDefaultsFor(state.view, pressedCard);
+      state.modalMode = 'create';
+      state.editingId = null;
+      $('#editModalTitle').textContent = 'New memory';
+      $('#editSaveBtn').textContent = 'Create';
+      const districts = H.CANONICAL_DISTRICTS;
+      $('#editDistrict').innerHTML = districts.map(d => `<option value="${esc(d)}">${esc(d)}</option>`).join('');
+      $('#editContent').value = '';
+      $('#editDistrict').value = defaults.district || 'practical_execution';
+      // Seeded the same way openEditModal does, so submitEdit's "only send a
+      // district the user actually chose" guard behaves identically in both modes.
+      state.editingDistrict = $('#editDistrict').value;
+      $('#editProject').value = defaults.projectId ?? '';
+      $('#editVisibility').value = 'private';
+      $('#editIntensity').value = '0.5';
+      $('#editEpistemic').value = '';
+      $('#editTags').value = '';
+      $('#editModalBg').classList.add('open');
+      $('#editContent').focus();
+    }
     function openEditModal(m){
       state.editingId = m.id;
+      state.modalMode = 'edit';
+      $('#editModalTitle').textContent = 'Edit memory';
+      $('#editSaveBtn').textContent = 'Save changes';
       const districts = CANONICAL.includes(m.district) || !m.district ? CANONICAL : [m.district, ...CANONICAL];
       $('#editDistrict').innerHTML = districts.map(d => `<option value="${esc(d)}">${esc(d)}</option>`).join('');
       $('#editContent').value = m.content || '';
@@ -1643,55 +1672,60 @@
       $('#editContent').focus(); // must follow .open — a display:none field cannot take focus
     }
     async function submitEdit(){
+      const creating = state.modalMode === 'create';
       const content = $('#editContent').value.trim();
       if (!content) { showToast('Content cannot be empty.'); return; }
       const project = $('#editProject').value.trim();
+      const district = $('#editDistrict').value;
+      const rawIntensity = $('#editIntensity').value.trim();
+      const epistemic = $('#editEpistemic').value;
+
       const body = {
-        memoryId: state.editingId,
         content,
         visibility: $('#editVisibility').value,
         projectId: project === '' ? null : project,
         tags: $('#editTags').value.split(',').map(s => s.trim()).filter(Boolean),
       };
+      if (!creating) body.memoryId = state.editingId;
       // The bridge forwards only the keys present, leaving everything else
-      // untouched, so an untouched control must send nothing. An emptied number
-      // field reads as '' and would post intensity: NaN; an unchanged district
-      // select would post the placeholder value shown for district-less memories.
+      // untouched, so an untouched control must send nothing. Editing sends a
+      // district only when the user actually changed it, so an untouched select
+      // cannot silently refile a district-less memory. Creating must always
+      // send one -- there is nothing to preserve.
+      if (creating || district !== state.editingDistrict) body.district = district;
+      // An emptied number field reads as '' and would post intensity: NaN.
       // Same validation as the classic app's edit modal: Number('') is 0 (hence
       // the empty check), Number('abc') is NaN which serialises to null and the
       // daemon rejects, and the min/max attributes do not constrain a
       // script-submitted form — so a typed 5 would otherwise persist off-scale.
-      const intensity = $('#editIntensity').value.trim();
-      if (intensity !== '') {
-        const n = Number(intensity);
-        if (!Number.isFinite(n) || n < 0 || n > 1) {
-          showToast('Intensity must be a number between 0 and 1.');
-          return;
-        }
+      if (rawIntensity !== '') {
+        const n = Number(rawIntensity);
+        if (!Number.isFinite(n) || n < 0 || n > 1) { showToast('Intensity must be a number between 0 and 1.'); return; }
         body.intensity = n;
       }
-      const district = $('#editDistrict').value;
-      if (district !== state.editingDistrict) body.district = district;
-      const epistemic = $('#editEpistemic').value;
       if (epistemic) body.epistemicStatus = epistemic;
+
+      const route = creating ? '/save' : '/update';
+      let res, data;
       try {
-        const res = await fetch(`${BRIDGE}/update`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-        const data = await res.json();
-        if (!res.ok || !data.ok) throw new Error('update failed');
-        $('#editModalBg').classList.remove('open');
-        showToast('Update routed through the bridge.');
-        // The snapshot is otherwise only fetched at init, so both the card and a
-        // reopened modal would keep showing pre-edit values — and a second edit of
-        // the same memory would re-POST that stale content, silently reverting the
-        // first. This runs last so a reconcile toast ("centered card was removed",
-        // "this view emptied") lands after the success toast and survives, instead
-        // of being overwritten by it. Refresh failure is caught separately: the
-        // save already succeeded, so a stale card is acceptable but a stuck modal
-        // (or a false failure toast from the outer catch) is not.
-        try { await loadSnapshot(); refreshAndReconcile(); } catch {}
+        res = await fetch(`${BRIDGE}${route}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+        data = await res.json();
       } catch {
-        showToast('Update failed — the modal is untouched, fix and retry.');
+        showToast('Could not reach the bridge — nothing was saved.');
+        return;
       }
+      if (!res.ok || !data.ok) { showToast(creating ? 'Create failed.' : 'Update failed.'); return; }
+      $('#editModalBg').classList.remove('open');
+      showToast(creating ? 'Memory created.' : 'Memory updated.');
+      // The snapshot is otherwise only fetched at init, so both the card and a
+      // reopened modal would keep showing pre-edit values — and a second edit of
+      // the same memory would re-POST that stale content, silently reverting the
+      // first. This runs last so a reconcile toast ("centered card was removed",
+      // "this view emptied") lands after the success toast and survives, instead
+      // of being overwritten by it. Refresh failure is caught separately: the
+      // save already succeeded, so a stale card is acceptable but a stuck modal
+      // (or a false failure toast from the outer catch) is not.
+      try { await loadSnapshot(); refreshAndReconcile(); } catch {}
     }
 
     // ---------- project rename ----------
@@ -1875,6 +1909,7 @@
       const card = btn.closest('.card3d.front');
       if (card) card.classList.toggle('flipped', btn.dataset.flip === 'open');
     });
+    els.createBtn.addEventListener('click', () => openCreateModal());
     $('#editCancelBtn').addEventListener('click', () => $('#editModalBg').classList.remove('open'));
     $('#editSaveBtn').addEventListener('click', submitEdit);
     $('#editModalBg').addEventListener('click', (e) => { if (e.target.id === 'editModalBg') $('#editModalBg').classList.remove('open'); });

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -66,6 +66,22 @@
     #crumb .seg:disabled:hover{background:none}
     #crumb .sep{color:var(--faint);padding:0 1px}
     #position{flex:0 0 auto;font-size:.78rem;color:var(--muted);white-space:nowrap}
+    /* Shares the band's row. While a query is active the coordinate hides: the
+       coordinate answers "where am I", the query answers "what am I looking
+       for", and both are rarely needed at once. The row already wraps at every
+       width and is already guarded at five viewports. */
+    #searchInput{flex:1 1 12rem;min-width:0;padding:4px 10px;border-radius:999px;
+      border:1px solid var(--surfaceBorder);background:var(--wash);color:var(--text);
+      font:inherit;font-size:.82rem}
+    #searchInput::placeholder{color:var(--faint)}
+    /* visibility, not display:none: #crumb wraps to two lines at real
+       coordinate depths on a narrow viewport (see the #chrome comment above),
+       so REMOVING it from flow shrinks #locus, which shrinks the measured
+       --chromeH #stage insets by, which moves every card up the moment a
+       query starts -- caught by the "search must not move a single card"
+       test on mobile-safari at the memories depth. Keeping its box (just
+       painted transparent) holds #chrome's height steady either way. */
+    #locus.searching #crumb{visibility:hidden}
     /* Inset below the chrome rather than sitting under it. #chrome is fixed, so
        for as long as #stage started at the viewport top the bar simply COVERED
        the card — harmless while the coordinate was one ellipsised pill, and not
@@ -105,6 +121,15 @@
     #stage[data-level="memories"]{--cardH:min(500px, 88%)}
     .card3d{position:absolute;inset:0;display:flex;flex-direction:column;gap:10px;padding:18px;border-radius:24px;border:1px solid var(--surfaceBorder);background:var(--cardWash),radial-gradient(circle at top right,rgba(var(--tint),.16),transparent 38%),var(--cardBase);box-shadow:0 18px 40px rgba(0,0,0,.35);backface-visibility:hidden;transition:opacity .3s,box-shadow .3s,border-color .3s,transform .25s ease;opacity:.55}
     .card3d.front{opacity:1;border-color:rgba(var(--tint),.4);box-shadow:0 24px 60px rgba(0,0,0,.5),0 0 30px rgba(var(--tint),.12)}
+    /* Dim the misses; light the hits. Composes with the existing card states
+       rather than replacing them -- .flipped and the ::after affordance below
+       are untouched. Declared AFTER .card3d.front on purpose: equal
+       specificity (two classes each) means source order decides, and the
+       front card's own opacity/border-color rule above would otherwise always
+       win, silently hiding the classification on exactly the one card being
+       looked at. */
+    .card3d.search-dim{opacity:.25}
+    .card3d.search-hit{border-color:var(--primary)}
     /* A sign, not a control. Chromium cannot hit-test a 3D-rotated card —
        pointer events AND elementFromPoint both return #scene — which is why
        every real button lives on .card3d.front only. A pseudo-element adds no
@@ -360,7 +385,7 @@
       <button class="pill" id="themeBtn" title="Toggle theme">◐</button>
       <a class="pill" href="/">Classic view</a>
     </div>
-    <div id="locus"><span id="crumb"></span><span id="position">—</span></div>
+    <div id="locus"><input id="searchInput" type="search" placeholder="Search memories…" autocomplete="off" spellcheck="false" /><span id="crumb"></span><span id="position">—</span></div>
   </div>
   <div id="stage" data-level="projects"><div id="scene"><div id="drum"></div></div></div>
   <div id="spin">
@@ -421,7 +446,7 @@
     const NODE_LABEL_PX = 58; // 10 monospace chars at .6rem; see truncateNodeLabel
 
     const $ = s => document.querySelector(s);
-    const els = { stage: $('#stage'), scene: $('#scene'), drum: $('#drum'), crumb: $('#crumb'), position: $('#position'), connState: $('#connState'), backBtn: $('#backBtn'), overlay: $('#overlay'), overlayMsg: $('#overlayMsg'), retryBtn: $('#retryBtn'), toast: $('#toast'), hudHint: $('#hudHint'), minimap: $('#minimap'), mapBody: $('#mapBody'), mapToggle: $('#mapToggle'), spin: $('#spin'), spinPrev: $('#spinPrev'), spinNext: $('#spinNext'), helpBtn: $('#helpBtn'), helpModalBg: $('#helpModalBg'), createBtn: $('#createBtn') };
+    const els = { stage: $('#stage'), scene: $('#scene'), drum: $('#drum'), crumb: $('#crumb'), position: $('#position'), connState: $('#connState'), backBtn: $('#backBtn'), overlay: $('#overlay'), overlayMsg: $('#overlayMsg'), retryBtn: $('#retryBtn'), toast: $('#toast'), hudHint: $('#hudHint'), minimap: $('#minimap'), mapBody: $('#mapBody'), mapToggle: $('#mapToggle'), spin: $('#spin'), spinPrev: $('#spinPrev'), spinNext: $('#spinNext'), helpBtn: $('#helpBtn'), helpModalBg: $('#helpModalBg'), createBtn: $('#createBtn'), searchInput: $('#searchInput'), locus: $('#locus') };
 
     // Three hand-tuned offsets (64/108/56) each encoded a guess at how tall
     // #chrome renders at that breakpoint. The band would have needed a fourth.
@@ -466,6 +491,7 @@
       editingDistrict: null, // district the edit modal was seeded with, to detect a real change
       modalMode: null,       // 'edit' or 'create' -- which mode the edit modal is currently wearing
       renamingProject: null,
+      search: { query: '', hits: new Map() },
     };
 
     function esc(v){ return String(v ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
@@ -757,6 +783,7 @@
       fillReader(next, state.items[idx]?.data?.content ?? '');
       state.view.centeredId = centeredItem()?.id ?? null;
       updateChrome();
+      renderSearchState();
     }
 
     function depthNow(){ return H.navDepth(state.tree); }
@@ -901,6 +928,23 @@
       // A fan has ends: stepping past one is a no-op rather than a wrap
       // (selectCard's own clamp), and selectCard drives the rotation there.
       if (state.layout.mode === 'fan') { selectCard(state.frontIndex + n); return; }
+      // While a search is active, step hit-to-hit: a 364-memory bucket is not
+      // worth spinning through one dark card at a time.
+      if (state.search.hits.size) {
+        const target = H.nextLitIndex(state.items, state.search.hits, state.snapshot, state.view, state.frontIndex, n > 0 ? 1 : -1);
+        if (target === state.frontIndex) return;
+        // Relative to the CURRENT rotation, not the target's raw angle: this
+        // drum accumulates real turns as it spins (see the identical
+        // `state.rotation + H.shortestDelta(...)` a few lines below), so handing
+        // rotationForCard's absolute small-range angle straight to stepTarget
+        // would send a heavily-spun drum the long way around -- laps of empty
+        // rotation to reach a card it could have turned to directly.
+        const goal = state.rotation + H.shortestDelta(state.rotation, H.rotationForCard(target, state.layout));
+        state.velocity = 0;
+        if (REDUCED) { state.stepTarget = null; state.rotation = goal; applyDrumTransform(); }
+        else state.stepTarget = goal;
+        return;
+      }
       const raw = state.frontIndex + n;
       const idx = ((raw % count) + count) % count;
       if (idx === state.frontIndex) return;
@@ -1696,6 +1740,58 @@
     }
     els.spinPrev.addEventListener('click', () => spinFromButton('arrowLeft'));
     els.spinNext.addEventListener('click', () => spinFromButton('arrowRight'));
+
+    // ---------- search ----------
+    // Applied to the rendered window only, and re-applied after any rebuild.
+    function renderSearchState(){
+      const { hits } = state.search;
+      els.drum.querySelectorAll('.card3d[data-idx]').forEach((el) => {
+        const item = state.items[Number(el.dataset.idx)];
+        if (!item || !hits.size) { el.classList.remove('search-dim', 'search-hit'); return; }
+        const lit = H.isLit(item, hits, state.snapshot, state.view);
+        el.classList.toggle('search-hit', lit);
+        el.classList.toggle('search-dim', !lit);
+      });
+    }
+    // 250ms debounce, and a later query always wins: /search is a daemon round
+    // trip, so a call per keystroke would both lag and land out of order.
+    let searchTimer = null;
+    let searchSeq = 0;
+    async function runSearch(query){
+      const seq = ++searchSeq;
+      if (!query) { state.search = { query: '', hits: new Map() }; renderSearchState(); return; }
+      try {
+        const res = await fetch(`${BRIDGE}/search?q=${encodeURIComponent(query)}`);
+        const data = await res.json();
+        if (seq !== searchSeq) return; // superseded
+        state.search = { query, hits: new Map((data.hits || []).map(h => [h.id, h.score])) };
+      } catch {
+        if (seq !== searchSeq) return;
+        state.search = { query, hits: new Map() };
+        showToast('Search could not reach the bridge.');
+      }
+      renderSearchState();
+    }
+    els.searchInput.addEventListener('input', () => {
+      const q = els.searchInput.value.trim();
+      els.locus.classList.toggle('searching', q !== '');
+      clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => runSearch(q), 250);
+    });
+    els.searchInput.addEventListener('keydown', (e) => {
+      // Escape clears the query, never a modal or a zoom-out. Verified against
+      // the real listeners, not assumed: opening any modal moves focus off this
+      // input (confirmed by driving it), so this handler only ever runs while
+      // #searchInput itself has focus. Nothing behaves differently just because
+      // a modal happens to be open elsewhere in the DOM -- the window-level
+      // handler's own `t.closest('input, textarea, select')` bail-out is what
+      // already keeps THIS Escape from reaching its zoomOut/modal-close logic,
+      // the same guard that protects every other text field on the page.
+      // stopPropagation is defensive, matching the modal-scoped Escape
+      // handlers' own convention, though the bail-out above means it is not
+      // load-bearing here the way it is for them.
+      if (e.key === 'Escape') { e.stopPropagation(); els.searchInput.value = ''; els.locus.classList.remove('searching'); clearTimeout(searchTimer); runSearch(''); }
+    });
 
     // ---------- edit modal ----------
     const CANONICAL = H.CANONICAL_DISTRICTS;

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -128,6 +128,11 @@
       background:var(--wash);font-size:.72rem;line-height:1.3;letter-spacing:.02em;
       color:var(--muted);pointer-events:none}
     .card3d{cursor:pointer}
+    /* iOS shows a selection callout on a long press. The gesture means "create"
+       on project and district cards, so suppress it there -- but NEVER on
+       .reader-scroll, whose user-select:text is deliberate and is how a memory
+       is read and copied. */
+    #stage:not([data-level="memories"]) .card3d{-webkit-touch-callout:none}
     @media (hover:hover){.card3d:not(.front):hover{opacity:.75}}
     .card3d .kicker{font-size:.7rem;text-transform:uppercase;letter-spacing:.1em;color:var(--faint)}
     .card3d h2{font-family:var(--font-display);font-size:1.15rem;line-height:1.2}
@@ -1228,12 +1233,23 @@
     let pinchStart = 0, dragMoved = 0;
     let pressTarget = null;        // pointerdown's target: the browser's real 3D hit-test
     let dragOrigin = { x: 0, y: 0 };
+    // Long-press: 500ms with the pointer essentially still. Cancelled by any
+    // real movement, a second pointer, or release -- so it can never fire in the
+    // middle of a spin, a pinch, or a reader drag.
+    const LONG_PRESS_MS = 500;
+    const LONG_PRESS_SLOP_PX = 10;
+    let longPressTimer = null;
+    function cancelLongPress(){ if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; } }
     els.stage.addEventListener('pointerdown', (e) => {
       // Capture so a drag that wanders over the fixed chrome bar (or off the
       // window) keeps delivering pointermove/pointerup to the stage. Without it
       // the release is never seen and state.dragging stays stuck true.
       try { els.stage.setPointerCapture(e.pointerId); } catch {}
       pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      // A second pointer means a pinch, not a long-press: pointers.size === 1
+      // already gates arming below, but an existing timer from the first
+      // pointer must still die or it would fire mid-pinch.
+      if (pointers.size > 1) cancelLongPress();
       if (pointers.size === 2) {
         const [a, b] = [...pointers.values()];
         pinchStart = Math.hypot(a.x - b.x, a.y - b.y);
@@ -1249,6 +1265,22 @@
         // — events and elementFromPoint both report #scene — and resolve
         // geometrically in cardIndexAtPoint instead.
         pressTarget = e.target instanceof Element ? e.target : null;
+        cancelLongPress();
+        if (pointers.size === 1 && H.routeGesture('longPress', { level: state.view.level, insideReader: false }) === 'create') {
+          const px = e.clientX, py = e.clientY;
+          longPressTimer = setTimeout(() => {
+            longPressTimer = null;
+            // Resolve through the geometric hit-test: Chromium cannot hit-test a
+            // rotated side card, so e.target alone would resolve to #scene.
+            const idx = cardIndexAtPoint(px, py);
+            const item = idx >= 0 ? state.items[idx] : null;
+            if (!item) return;
+            // Suppress the click that release would otherwise produce, so the
+            // press does not also dive into the card it just created from.
+            dragMoved = 999;
+            openCreateModal({ kind: item.kind, id: item.id });
+          }, LONG_PRESS_MS);
+        }
         // A horizontal drag spins at every level, reader included (spec: hdrag ->
         // spin). Only a mouse is exempt inside the reader, where press-and-drag
         // is how text gets selected.
@@ -1325,6 +1357,7 @@
       if (pointers.size === 1) {
         dragMoved = Math.max(dragMoved, Math.abs(e.clientX - dragOrigin.x) + Math.abs(e.clientY - dragOrigin.y));
       }
+      if (longPressTimer && (Math.abs(e.clientX - dragOrigin.x) > LONG_PRESS_SLOP_PX || Math.abs(e.clientY - dragOrigin.y) > LONG_PRESS_SLOP_PX)) cancelLongPress();
       if (readerDrag && pointers.size === 1) {
         const ndx = e.clientX - dragOrigin.x, ndy = e.clientY - dragOrigin.y;
         if (readerDrag.axis === 'undecided') {
@@ -1389,6 +1422,7 @@
       }
     });
     function releasePointer(e){
+      cancelLongPress();
       pointers.delete(e.pointerId);
       if (pointers.size < 2) pinchStart = 0;
       if (!pointers.size) { state.dragging = false; endReaderDrag(); }

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -1266,7 +1266,22 @@
         // geometrically in cardIndexAtPoint instead.
         pressTarget = e.target instanceof Element ? e.target : null;
         cancelLongPress();
-        if (pointers.size === 1 && H.routeGesture('longPress', { level: state.view.level, insideReader: false }) === 'create') {
+        // A slow, careful click on a real control (Rename…, today's only
+        // create-eligible-level example) is an ordinary click, not a long
+        // press -- holding still is what a deliberate click looks like, unlike
+        // the movement/second-pointer/release cancellations above, which all
+        // require the user to have done something else. Two checks, matching
+        // the click handler's own two-layer pattern below: pressTarget's
+        // closest('button, a') is the cheap DOM-hit-test check ('button, a'
+        // is the same selector the click handler uses, and routeGesture's doc
+        // comment on "Controls inside a card" already names the convention),
+        // then frontControlAt as the geometric fallback that is actually
+        // load-bearing here -- measured directly that WebKit's hit-test for a
+        // point over the front card's OWN button can return a completely
+        // unrelated side card's div instead (see frontControlAt's comment),
+        // which makes pressTarget alone unreliable for exactly this check.
+        const onControl = !!pressTarget?.closest('button, a') || !!frontControlAt(e.clientX, e.clientY);
+        if (pointers.size === 1 && !onControl && H.routeGesture('longPress', { level: state.view.level, insideReader: false }) === 'create') {
           const px = e.clientX, py = e.clientY;
           longPressTimer = setTimeout(() => {
             longPressTimer = null;
@@ -1520,6 +1535,35 @@
       return best;
     }
     /**
+     * The front card's own real control (button/link) at a point, found by
+     * bounding-box containment rather than DOM hit-testing.
+     *
+     * This has to be geometric, not `e.target`/elementFromPoint-based: on
+     * WebKit, elementsFromPoint at a point over the FRONT card's own button
+     * can return an entirely unrelated SIDE card's plain div ahead of that
+     * button in the hit-test order -- measured directly (a project card's
+     * Rename… button at (292,317) resolved via pointerdown's e.target to a
+     * different card's data-idx="10" div, not the button at all, purely
+     * because that side card's flat, unrotated bounding box happens to
+     * overlap the same screen pixel). `pressTarget`, being `e.target`,
+     * inherits that unreliability. A real element's own rect, checked
+     * directly, sidesteps the hit-test entirely -- the same reasoning
+     * `cardIndexAtPoint` above already relies on for resolving WHICH card,
+     * extended here to resolving WHICH CONTROL.
+     *
+     * Originally inline in the click handler below (as `overFrontButton`);
+     * factored out because the long-press arming guard needs the identical
+     * check at pointerdown time.
+     */
+    function frontControlAt(x, y) {
+      if (!state.frontEl) return null;
+      for (const el of state.frontEl.querySelectorAll('button, a')) {
+        const r = el.getBoundingClientRect();
+        if (r.width && x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return el;
+      }
+      return null;
+    }
+    /**
      * The element a click should be attributed to.
      *
      * pressTarget is pointerdown's target, kept because pointer capture
@@ -1570,14 +1614,9 @@
       // half of an angled card, so this check was the only thing standing
       // between that click and a wrong dive; measured on a 3-card fan back
       // then, Edit worked at -24deg and 0deg but dived at +24deg without it.
-      const overFrontButton = (() => {
-        if (!state.frontEl) return null;
-        for (const el of state.frontEl.querySelectorAll('button, a')) {
-          const r = el.getBoundingClientRect();
-          if (r.width && e.clientX >= r.left && e.clientX <= r.right && e.clientY >= r.top && e.clientY <= r.bottom) return el;
-        }
-        return null;
-      })();
+      // (Factored out as frontControlAt, above -- the long-press guard needs
+      // the identical geometric check at pointerdown time.)
+      const overFrontButton = frontControlAt(e.clientX, e.clientY);
       if (overFrontButton) {
         // The other two delegated click listeners on #stage (rename, edit) resolve
         // their own `hit` the same pressTarget-first way this one does, and pressTarget

--- a/test/bridge-search-contract.test.mjs
+++ b/test/bridge-search-contract.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { getFreePort, waitForHealth, stopDaemonOnPort } from "../test-support/daemon.mjs";
+
+// The bridge recovers search hits by PARSING the daemon's prose. That contract
+// is invisible at runtime -- if the tool's wording changes, the parser silently
+// returns zero hits and search just looks broken. This test runs the REAL tool
+// against a seeded store and asserts the parser still recovers what it stored,
+// so a formatting change fails CI instead of production.
+test("the bridge's /search parses what search_memories actually emits", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ndm-search-contract-"));
+  const memoryFile = path.join(tempDir, "memories.json");
+  const bridgePort = await getFreePort();
+  const daemonPort = await getFreePort();
+
+  const bridge = spawn(process.execPath, ["scripts/nd-mem-bridge-server.mjs"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      ND_MEM_FILE: memoryFile,
+      NEURODIVERGENT_MEMORY_FILE: memoryFile,
+      NEURODIVERGENT_MEMORY_DIR: tempDir,
+      ND_MEM_BRIDGE_PORT: String(bridgePort),
+      ND_MEM_BRIDGE_OPEN: "0",
+      NEURODIVERGENT_MEMORY_DAEMON_PORT: String(daemonPort),
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let stderr = "";
+  bridge.stderr.on("data", (c) => { stderr += c.toString(); });
+
+  try {
+    await waitForHealth(`http://127.0.0.1:${bridgePort}/health`);
+
+    // Seed through the bridge's own write path so the daemon indexes it.
+    const save = await fetch(`http://127.0.0.1:${bridgePort}/save`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "deployment pipeline rollout checklist", district: "practical_execution" }),
+    });
+    assert.ok(save.ok, `seed save failed: ${save.status}\n${stderr}`);
+
+    const res = await fetch(`http://127.0.0.1:${bridgePort}/search?q=${encodeURIComponent("deployment")}`);
+    assert.ok(res.ok, `search failed: ${res.status}\n${stderr}`);
+    const body = await res.json();
+
+    assert.ok(Array.isArray(body.hits), `hits should be an array: ${JSON.stringify(body)}`);
+    assert.ok(body.hits.length > 0,
+      `THE PARSER RECOVERED NOTHING. Either search_memories' output format changed, or the regex in ` +
+      `parseSearchResults no longer matches it. Response: ${JSON.stringify(body)}\n${stderr}`);
+    for (const hit of body.hits) {
+      assert.match(hit.id, /^memory_/, `hit id should look like a memory id: ${JSON.stringify(hit)}`);
+      assert.ok(Number.isFinite(hit.score), `hit score should be a number: ${JSON.stringify(hit)}`);
+    }
+  } finally {
+    bridge.kill();
+    await stopDaemonOnPort(daemonPort);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/test/bridge-search-contract.test.mjs
+++ b/test/bridge-search-contract.test.mjs
@@ -6,11 +6,27 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { getFreePort, waitForHealth, stopDaemonOnPort } from "../test-support/daemon.mjs";
 
+/** Pulls `ID: memory_N` out of store_memory's prose, which /save passes through verbatim. */
+function seededId(saveBody) {
+  const text = saveBody?.result?.result?.result?.content?.map((c) => c?.text).filter(Boolean).join("\n") ?? "";
+  const m = /^ID:\s*(\S+)/m.exec(text);
+  return m ? m[1] : null;
+}
+
 // The bridge recovers search hits by PARSING the daemon's prose. That contract
 // is invisible at runtime -- if the tool's wording changes, the parser silently
 // returns zero hits and search just looks broken. This test runs the REAL tool
 // against a seeded store and asserts the parser still recovers what it stored,
 // so a formatting change fails CI instead of production.
+//
+// TWO memories are seeded, and one of them shares NO token with the query. With
+// only one seed, "the search returned the match" and "the search returned the
+// entire store" are the same response -- and the store really did return the
+// entire store, because search_memories defaults min_score to 0 and a document
+// matching no query term scores exactly 0. Every card in the rolodex was
+// therefore lit, and the dim-don't-filter design was inert in production while
+// this test stayed green. The absence assertion below is what makes that a CI
+// failure instead.
 test("the bridge's /search parses what search_memories actually emits", async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ndm-search-contract-"));
   const memoryFile = path.join(tempDir, "memories.json");
@@ -37,12 +53,21 @@ test("the bridge's /search parses what search_memories actually emits", async ()
     await waitForHealth(`http://127.0.0.1:${bridgePort}/health`);
 
     // Seed through the bridge's own write path so the daemon indexes it.
-    const save = await fetch(`http://127.0.0.1:${bridgePort}/save`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ content: "deployment pipeline rollout checklist", district: "practical_execution" }),
-    });
-    assert.ok(save.ok, `seed save failed: ${save.status}\n${stderr}`);
+    const seed = async (content, district) => {
+      const res = await fetch(`http://127.0.0.1:${bridgePort}/save`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content, district }),
+      });
+      assert.ok(res.ok, `seed save failed: ${res.status}\n${stderr}`);
+      const id = seededId(await res.json());
+      assert.ok(id, `store_memory did not report an ID for "${content}"\n${stderr}`);
+      return id;
+    };
+    const matchingId = await seed("deployment pipeline rollout checklist", "practical_execution");
+    // Deliberately shares not one token with the query, nor with the memory
+    // above -- neither content, nor the generated name, nor any tag.
+    const missId = await seed("banana bread cooled on a wire rack", "creative_synthesis");
 
     const res = await fetch(`http://127.0.0.1:${bridgePort}/search?q=${encodeURIComponent("deployment")}`);
     assert.ok(res.ok, `search failed: ${res.status}\n${stderr}`);
@@ -56,6 +81,16 @@ test("the bridge's /search parses what search_memories actually emits", async ()
       assert.match(hit.id, /^memory_/, `hit id should look like a memory id: ${JSON.stringify(hit)}`);
       assert.ok(Number.isFinite(hit.score), `hit score should be a number: ${JSON.stringify(hit)}`);
     }
+
+    const ids = body.hits.map((h) => h.id);
+    assert.ok(ids.includes(matchingId),
+      `the memory that actually contains "deployment" (${matchingId}) is missing from hits: ${JSON.stringify(body)}\n${stderr}`);
+    assert.ok(!ids.includes(missId),
+      `SEARCH RETURNED A NON-MATCH. ${missId} shares no term with "deployment", so it must not be a hit. ` +
+      `search_memories defaults min_score to 0 and scores an unmatched document exactly 0, so the bridge has to ` +
+      `drop score-0 rows itself; if it stops doing that, every card in the rolodex lights and search stops ` +
+      `discriminating. Response: ${JSON.stringify(body)}\n${stderr}`);
+    assert.equal(body.total, body.hits.length, `total must describe the hits actually returned: ${JSON.stringify(body)}`);
   } finally {
     bridge.kill();
     await stopDaemonOnPort(daemonPort);

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -775,3 +775,21 @@ test('parseSearchResults tolerates junk without throwing', () => {
   assert.deepEqual(parseSearchResults(null), []);
   assert.deepEqual(parseSearchResults('completely unrelated text'), []);
 });
+
+test('parseSearchResults preserves text order, not score order', () => {
+  // Hits appear in text order: 0.412, then 0.873. If the implementation
+  // silently added a score sort, this would become [0.873, 0.412]. The test
+  // must catch that. This guards against regressions that would silently
+  // discard the daemon's ranking work.
+  const textWithReversedScores = [
+    '🔍 Found 2 memories (ranked by BM25 relevance):',
+    '• [0.412] memory_9 — First hit by rank, lower score',
+    '  content snippet',
+    '• [0.873] memory_123 — Second hit by rank, higher score',
+    '  more content',
+  ].join('\n');
+  assert.deepEqual(parseSearchResults(textWithReversedScores), [
+    { id: 'memory_9', score: 0.412 },
+    { id: 'memory_123', score: 0.873 },
+  ]);
+});

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -14,6 +14,7 @@ import {
   hintFor,
   truncateNodeLabel, MINIMAP_COL,
   parseSearchResults,
+  isLit, nextLitIndex,
 } from '../scripts/nd-mem-rolodex-helpers.mjs';
 
 // Fixture: alpha has 3 memories in 2 districts, beta has 2 (one custom district),
@@ -792,4 +793,86 @@ test('parseSearchResults preserves text order, not score order', () => {
     { id: 'memory_9', score: 0.412 },
     { id: 'memory_123', score: 0.873 },
   ]);
+});
+
+const WALL = { level: 'projects', projectId: null, districtId: null };
+const IN_ALPHA = { level: 'districts', projectId: 'alpha', districtId: null };
+
+test('isLit lights a memory whose own id matched', () => {
+  const hits = new Map([['mem_1', 0.9]]);
+  assert.equal(isLit({ id: 'mem_1', kind: 'memory' }, hits, SNAP, WALL), true);
+  assert.equal(isLit({ id: 'mem_2', kind: 'memory' }, hits, SNAP, WALL), false);
+});
+
+test('isLit lights a project containing a hit', () => {
+  // mem_1 is project alpha, district practical_execution (see SNAP).
+  const hits = new Map([['mem_1', 0.9]]);
+  assert.equal(isLit({ id: 'alpha', kind: 'project' }, hits, SNAP, WALL), true);
+  assert.equal(isLit({ id: 'beta', kind: 'project' }, hits, SNAP, WALL), false);
+});
+
+test('isLit scopes a district to the project you are standing in', () => {
+  // THE POINT OF THE view ARGUMENT. District names are shared across projects,
+  // not globally unique buckets: SNAP has practical_execution memories under
+  // alpha. Standing inside beta, alpha's hit must NOT light beta's
+  // same-named district card.
+  const hitInAlpha = new Map([['mem_1', 0.9]]);
+  assert.equal(
+    isLit({ id: 'practical_execution', kind: 'district' }, hitInAlpha, SNAP, IN_ALPHA), true);
+  assert.equal(
+    isLit({ id: 'practical_execution', kind: 'district' }, hitInAlpha, SNAP,
+      { level: 'districts', projectId: 'beta', districtId: null }), false);
+  assert.equal(
+    isLit({ id: 'vigilant_monitoring', kind: 'district' }, hitInAlpha, SNAP, IN_ALPHA), false);
+});
+
+test('isLit scopes correctly when standing in the UNASSIGNED (no-project) bucket', () => {
+  // Not one of the brief's verbatim tests -- added during self-review to pin
+  // down a case the brief explicitly flagged as worth checking: view.projectId
+  // can be the UNASSIGNED sentinel ('(no project)'), not just a real project
+  // id, when you have drilled into that display bucket's districts. mem_5 (see
+  // SNAP) has no project_id and no district, so projectOf/districtOf both
+  // normalize it to UNASSIGNED/UNCATEGORIZED -- the same normalization
+  // isLit's scope check relies on, which is why this is not a bug: comparing
+  // projectOf(m) to the UNASSIGNED sentinel works exactly like comparing it to
+  // a real project id.
+  const IN_UNASSIGNED = { level: 'districts', projectId: UNASSIGNED, districtId: null };
+  const hitOnUnassigned = new Map([['mem_5', 0.9]]);
+  assert.equal(
+    isLit({ id: UNCATEGORIZED, kind: 'district' }, hitOnUnassigned, SNAP, IN_UNASSIGNED), true);
+  // A hit that belongs to alpha's practical_execution must not leak into the
+  // UNASSIGNED bucket's uncategorized card.
+  const hitInAlpha = new Map([['mem_1', 0.9]]);
+  assert.equal(
+    isLit({ id: UNCATEGORIZED, kind: 'district' }, hitInAlpha, SNAP, IN_UNASSIGNED), false);
+});
+
+test('isLit lights nothing when there are no hits', () => {
+  const none = new Map();
+  assert.equal(isLit({ id: 'mem_1', kind: 'memory' }, none, SNAP, WALL), false);
+  assert.equal(isLit({ id: 'alpha', kind: 'project' }, none, SNAP, WALL), false);
+});
+
+test('nextLitIndex walks to the next lit card and wraps', () => {
+  const items = [
+    { id: 'mem_1', kind: 'memory' },
+    { id: 'mem_2', kind: 'memory' },
+    { id: 'mem_3', kind: 'memory' },
+  ];
+  const hits = new Map([['mem_3', 0.5]]);
+  assert.equal(nextLitIndex(items, hits, SNAP, WALL, 0, 1), 2);
+  // From the only lit card, forward wraps back to itself.
+  assert.equal(nextLitIndex(items, hits, SNAP, WALL, 2, 1), 2);
+  assert.equal(nextLitIndex(items, hits, SNAP, WALL, 0, -1), 2);
+});
+
+test('nextLitIndex falls back to ordinary stepping when nothing is lit', () => {
+  const items = [
+    { id: 'mem_1', kind: 'memory' },
+    { id: 'mem_2', kind: 'memory' },
+  ];
+  const none = new Map();
+  assert.equal(nextLitIndex(items, none, SNAP, WALL, 0, 1), 1);
+  assert.equal(nextLitIndex(items, none, SNAP, WALL, 1, 1), 0);
+  assert.equal(nextLitIndex(items, none, SNAP, WALL, 0, -1), 1);
 });

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -10,6 +10,7 @@ import {
   LEVELS, nextLevel, createHistory, pushView, popView, atWall,
   itemIdsForView, reconcileView, reconcilePop,
   routeGesture, DRAG_AXIS_THRESHOLD_PX, classifyDragAxis, routeDragAxis,
+  createDefaultsFor,
   hintFor,
   truncateNodeLabel, MINIMAP_COL,
 } from '../scripts/nd-mem-rolodex-helpers.mjs';
@@ -665,4 +666,52 @@ test('layoutNavTree columns leave room for a truncated label', () => {
   // If the pitch ever drops back below that, labels from adjacent columns
   // collide and the map becomes less readable than the bare dots it replaced.
   assert.ok(MINIMAP_COL >= 67, `MINIMAP_COL is ${MINIMAP_COL}, too tight for a 10-char label`);
+});
+
+test('createDefaultsFor inherits nothing at the projects level', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'projects', projectId: null, districtId: null }, null),
+    { projectId: null, district: null },
+  );
+});
+
+test('createDefaultsFor inherits the project at the districts level', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'districts', projectId: 'alpha', districtId: null }, null),
+    { projectId: 'alpha', district: null },
+  );
+});
+
+test('createDefaultsFor inherits project and district at the memories level', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'memories', projectId: 'alpha', districtId: 'logical_analysis' }, null),
+    { projectId: 'alpha', district: 'logical_analysis' },
+  );
+});
+
+test('createDefaultsFor takes a long-pressed project card over the current view', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'projects', projectId: null, districtId: null }, { kind: 'project', id: 'beta' }),
+    { projectId: 'beta', district: null },
+  );
+});
+
+test('createDefaultsFor takes a long-pressed district card with its parent project', () => {
+  assert.deepEqual(
+    createDefaultsFor({ level: 'districts', projectId: 'alpha', districtId: null }, { kind: 'district', id: 'vigilant_monitoring' }),
+    { projectId: 'alpha', district: 'vigilant_monitoring' },
+  );
+});
+
+test('createDefaultsFor never inherits the unassigned sentinel as a real project', () => {
+  // '(no project)' is a display bucket, not a project id -- storing it would
+  // create a literal project named after the placeholder.
+  assert.deepEqual(
+    createDefaultsFor({ level: 'districts', projectId: UNASSIGNED, districtId: null }, null),
+    { projectId: null, district: null },
+  );
+  assert.deepEqual(
+    createDefaultsFor({ level: 'projects', projectId: null, districtId: null }, { kind: 'project', id: UNASSIGNED }),
+    { projectId: null, district: null },
+  );
 });

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -715,3 +715,17 @@ test('createDefaultsFor never inherits the unassigned sentinel as a real project
     { projectId: null, district: null },
   );
 });
+
+test('createDefaultsFor never inherits the uncategorized sentinel as a real district', () => {
+  // 'uncategorized' is a display bucket for memories with no district, not a
+  // district id -- storing it would create a literal district named after the
+  // placeholder. Just like UNASSIGNED, it should fall back to null.
+  assert.deepEqual(
+    createDefaultsFor({ level: 'memories', projectId: 'alpha', districtId: UNCATEGORIZED }, null),
+    { projectId: 'alpha', district: null },
+  );
+  assert.deepEqual(
+    createDefaultsFor({ level: 'districts', projectId: 'alpha', districtId: null }, { kind: 'district', id: UNCATEGORIZED }),
+    { projectId: 'alpha', district: null },
+  );
+});

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -10,7 +10,7 @@ import {
   LEVELS, nextLevel, createHistory, pushView, popView, atWall,
   itemIdsForView, reconcileView, reconcilePop,
   routeGesture, DRAG_AXIS_THRESHOLD_PX, classifyDragAxis, routeDragAxis,
-  createDefaultsFor,
+  createDefaultsFor, districtOptions,
   hintFor,
   truncateNodeLabel, MINIMAP_COL,
   parseSearchResults,
@@ -730,6 +730,28 @@ test('createDefaultsFor never inherits the uncategorized sentinel as a real dist
     createDefaultsFor({ level: 'districts', projectId: 'alpha', districtId: null }, { kind: 'district', id: UNCATEGORIZED }),
     { projectId: 'alpha', district: null },
   );
+});
+
+test('districtOptions always contains the district the select is about to be set to', () => {
+  // The invariant: whatever createDefaultsFor (or a memory being edited) hands
+  // the modal, the <select> must have an <option> for it. Miss that and the
+  // browser reports selectedIndex -1 and renders the field BLANK -- which is
+  // what create mode did for every non-canonical district, and then posted the
+  // resulting empty string as the new memory's district.
+  assert.deepEqual(districtOptions('logical_analysis'), CANONICAL_DISTRICTS);
+  assert.deepEqual(districtOptions(null), CANONICAL_DISTRICTS);
+  assert.deepEqual(districtOptions(''), CANONICAL_DISTRICTS);
+  // 'weird_custom' is in the fixture snapshot precisely because register_district
+  // is a supported tool and deriveDistricts renders a card for it.
+  assert.deepEqual(districtOptions('weird_custom'), ['weird_custom', ...CANONICAL_DISTRICTS]);
+  assert.equal(districtOptions('weird_custom')[0], 'weird_custom', 'the stray district leads, as in the edit modal');
+  for (const d of ['weird_custom', 'progressiongraph_debug', ...CANONICAL_DISTRICTS]) {
+    assert.ok(districtOptions(d).includes(d), `a select built from districtOptions(${d}) could not hold ${d}`);
+  }
+  // Never mutates the shared canonical list.
+  districtOptions('weird_custom');
+  assert.deepEqual(CANONICAL_DISTRICTS,
+    ['logical_analysis', 'emotional_processing', 'practical_execution', 'vigilant_monitoring', 'creative_synthesis']);
 });
 
 test('routeGesture maps a long press to create, except on memory cards', () => {

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -840,11 +840,30 @@ test('isLit scopes correctly when standing in the UNASSIGNED (no-project) bucket
   const hitOnUnassigned = new Map([['mem_5', 0.9]]);
   assert.equal(
     isLit({ id: UNCATEGORIZED, kind: 'district' }, hitOnUnassigned, SNAP, IN_UNASSIGNED), true);
-  // A hit that belongs to alpha's practical_execution must not leak into the
-  // UNASSIGNED bucket's uncategorized card.
-  const hitInAlpha = new Map([['mem_1', 0.9]]);
+
+  // The assertion above cannot, by itself, prove the scope comparison runs at
+  // all: mem_5's project already normalizes to UNASSIGNED, so it passes
+  // whether or not the scope check exists. To actually exercise the scope
+  // comparison we need a memory whose district ALSO normalizes to
+  // UNCATEGORIZED but whose project is real and not UNASSIGNED -- SNAP has no
+  // such memory (every SNAP memory with an empty district also has an empty
+  // project_id), so building one here, locally, rather than editing the
+  // shared SNAP fixture that other tests depend on.
+  const withElsewhereUncategorized = {
+    ...SNAP,
+    memories: {
+      ...SNAP.memories,
+      // mem_7: real project ('beta', not alpha, not UNASSIGNED), no district
+      // -> districtOf normalizes it to UNCATEGORIZED. This is the one shape
+      // that can distinguish "scoped" from "unscoped": without the project
+      // check, this memory's UNCATEGORIZED district would incorrectly light
+      // the UNASSIGNED bucket's uncategorized card too.
+      mem_7: { id: 'mem_7', name: 'Beta loose', content: 'loose body', district: '', project_id: 'beta', tags: [], created: '2026-07-07T10:00:00Z' },
+    },
+  };
+  const hitElsewhere = new Map([['mem_7', 0.9]]);
   assert.equal(
-    isLit({ id: UNCATEGORIZED, kind: 'district' }, hitInAlpha, SNAP, IN_UNASSIGNED), false);
+    isLit({ id: UNCATEGORIZED, kind: 'district' }, hitElsewhere, withElsewhereUncategorized, IN_UNASSIGNED), false);
 });
 
 test('isLit lights nothing when there are no hits', () => {
@@ -875,4 +894,21 @@ test('nextLitIndex falls back to ordinary stepping when nothing is lit', () => {
   assert.equal(nextLitIndex(items, none, SNAP, WALL, 0, 1), 1);
   assert.equal(nextLitIndex(items, none, SNAP, WALL, 1, 1), 0);
   assert.equal(nextLitIndex(items, none, SNAP, WALL, 0, -1), 1);
+});
+
+test('nextLitIndex falls back to ordinary stepping when hits exist but none land in this drum', () => {
+  // Distinct code path from the test above: there hits.size === 0 takes the
+  // early return before the sweep ever starts. Here hits is non-empty, so the
+  // sweep runs a full lap checking every item, finds nothing lit (mem_99 isn't
+  // among these three cards at all), and only THEN falls through to the same
+  // plain-stepping answer. Without this, the loop-exhausted fallback line
+  // could be deleted or broken and no test would notice.
+  const items = [
+    { id: 'mem_1', kind: 'memory' },
+    { id: 'mem_2', kind: 'memory' },
+    { id: 'mem_3', kind: 'memory' },
+  ];
+  const hits = new Map([['mem_99', 0.9]]);
+  assert.equal(nextLitIndex(items, hits, SNAP, WALL, 0, 1), 1);
+  assert.equal(nextLitIndex(items, hits, SNAP, WALL, 0, -1), 2);
 });

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -13,6 +13,7 @@ import {
   createDefaultsFor,
   hintFor,
   truncateNodeLabel, MINIMAP_COL,
+  parseSearchResults,
 } from '../scripts/nd-mem-rolodex-helpers.mjs';
 
 // Fixture: alpha has 3 memories in 2 districts, beta has 2 (one custom district),
@@ -735,4 +736,42 @@ test('routeGesture maps a long press to create, except on memory cards', () => {
   assert.equal(routeGesture('longPress', { level: 'projects', insideReader: false }), 'create');
   assert.equal(routeGesture('longPress', { level: 'districts', insideReader: false }), 'create');
   assert.equal(routeGesture('longPress', { level: 'memories', insideReader: false }), 'none');
+});
+
+const SEARCH_TEXT = [
+  '🔍 Found 2 memories (ranked by BM25 relevance):',
+  '• [0.873] memory_123 — Some title (scholar)',
+  '  first eighty characters of content…',
+  '• [0.412] memory_9 — Another title (merchant)',
+  '  more content here',
+].join('\n');
+
+test('parseSearchResults recovers id and score, in rank order', () => {
+  assert.deepEqual(parseSearchResults(SEARCH_TEXT), [
+    { id: 'memory_123', score: 0.873 },
+    { id: 'memory_9', score: 0.412 },
+  ]);
+});
+
+test('parseSearchResults returns nothing for a no-results response', () => {
+  assert.deepEqual(parseSearchResults('🔍 No memories found matching query: "zzz"'), []);
+});
+
+test('parseSearchResults ignores the did-you-mean suffix', () => {
+  const text = SEARCH_TEXT + '\nDid you mean project_id: alpha?';
+  assert.deepEqual(parseSearchResults(text).map(h => h.id), ['memory_123', 'memory_9']);
+});
+
+test('parseSearchResults ignores the partial-matches block, which also uses bullets', () => {
+  // Partial matches are formatted "• candidate (similarity=0.9, field=..., memories=memory_5, ...)".
+  // Those bullets carry no [score] prefix and must not be read as hits.
+  const text = SEARCH_TEXT +
+    '\n\nPartial matches:\n• alpah (similarity=0.833, field=project_id, memories=memory_5, projects=alpha)';
+  assert.deepEqual(parseSearchResults(text).map(h => h.id), ['memory_123', 'memory_9']);
+});
+
+test('parseSearchResults tolerates junk without throwing', () => {
+  assert.deepEqual(parseSearchResults(''), []);
+  assert.deepEqual(parseSearchResults(null), []);
+  assert.deepEqual(parseSearchResults('completely unrelated text'), []);
 });

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -729,3 +729,10 @@ test('createDefaultsFor never inherits the uncategorized sentinel as a real dist
     { projectId: 'alpha', district: null },
   );
 });
+
+test('routeGesture maps a long press to create, except on memory cards', () => {
+  // A memory card is a reading surface; there the gesture belongs to selection.
+  assert.equal(routeGesture('longPress', { level: 'projects', insideReader: false }), 'create');
+  assert.equal(routeGesture('longPress', { level: 'districts', insideReader: false }), 'create');
+  assert.equal(routeGesture('longPress', { level: 'memories', insideReader: false }), 'none');
+});


### PR DESCRIPTION
Closes #162. Closes #163. Closes #164. Closes #165. Closes #166. Closes #167. Closes #168. Closes #169.

The rolodex could read, navigate, rename and edit — but it could not **find by relevance** and could not **create**. The classic app has had both all along. This closes those two gaps. It adds no new ideas beyond them.

## The two decisions worth arguing about

**One modal, two modes — not a second create modal.** The classic app's near-duplicate modal already drifted from the rolodex's once, and that divergence was a real code-review finding, not a hypothetical. So `openCreateModal` and `openEditModal` drive the same DOM, and `submitEdit` branches on exactly three things: whether `memoryId` is present, whether the district is always sent, and which route it posts to. Edit-mode behaviour is otherwise byte-for-byte what it was.

**Search dims; it does not filter and it does not reorder.** The single advantage a 3D ring has over a list is that "my card was over there" stays true. Filtering or sorting would destroy exactly the thing the interface exists for. So a query classifies every rendered card lit or dim and *nothing moves* — the flagship test captures every card's bounding rect before and after the query and asserts they are identical. A card is lit if it, or anything inside it, matched, which is what lets one query re-interpret itself one level deeper on each dive instead of needing a separate results view.

## What's here

**Creation** — `createDefaultsFor` resolves what a new memory inherits from where you're standing (deeper = more context; a long-pressed card outranks the current view). The `+` button creates with nothing inherited at the wall; long-pressing a project or district card creates in that card's context. Not at the memories level — there a card is a reading surface and the press belongs to text selection.

**Search** — a `/search` route on the bridge ranks through the daemon, so the UI sees exactly what an agent would: same BM25, same tie-breaks, rather than a second divergent client-side filter. Stepping skips dark cards while a query is active, so a 364-memory bucket doesn't have to be spun through one card at a time.

## The one that nearly shipped broken

Seven task-scoped reviews passed. The whole-branch review then found the feature was **inert**.

`search_memories` defaults `min_score` to `0`, and `BM25Index.score` returns `0` for a document containing none of the query terms. `0 >= 0` passes, and there is no result cap — so *every memory in the store came back as a hit*. `isLit` was true for every card at every level. Typing a query did nothing visible except hide the coordinate.

Three tests were shaped so they passed in exactly that state: the dim test asserted `lit + dimmed === total` and `lit > 0` (both satisfied by `dimmed === 0`); the drill-down test counted the two classes together; and the contract test seeded a single memory, so "returns everything" and "returns the match" were the same response. Fixed at the bridge with `.filter(h => h.score > 0)` — not by passing an epsilon `min_score`, whose schema documents `minimum: 0` — and all three tests strengthened and then *proven* by reverting the fix and watching each one fail.

## Testing

| suite | before | after |
|---|---|---|
| `npm test` | 294 tests, 292 pass, 2 known fail | **318 tests, 316 pass, 2 known fail, 0 skipped** |
| `npx playwright test` | 51 passed / 1 skipped | **69 passed / 1 skipped** |

The 2 `npm test` failures are pre-existing wording drift in `test/agent-customization-wording.test.mjs`, present at the merge base and unrelated to this work. The 1 Playwright skip is the pre-existing desktop-only wheel guard — mobile WebKit has no wheel input. Zero new skips.

Every test in this branch was confirmed failing before it was made to pass. Where a test guards a property rather than a feature, the implementation was deliberately broken in the specific way the test exists to catch, and the failure recorded — the discipline that surfaced three could-not-fail tests, including the one hiding the inert-search bug.

## Not done here

- **iPhone confirmation.** Long-press callout suppression and the `@media (pointer:coarse){font-size:16px}` rule that prevents iOS focus-zoom cannot be gated by Playwright's WebKit, which is tap-only and exposes no CDP.
- **Two known Minors, deliberately parked.** `runSearch`'s two failure paths diverge — an HTTP failure leaves the previous classification standing while a network failure clears it; both toast. And `settleDrum`'s `waitForFunction` can settle early under WebKit rAF throttling; it fails red rather than false-green.
- **A worthwhile follow-up:** `diveToMemories` clicks the viewport centre rather than the stage centre, so the two browser projects land in different buckets. Untouched because it would move the bucket ~18 pre-existing specs run against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
