### PR TITLE
feat(rolodex): report the match count, so a single-hit arrow explains itself

### DIFF
--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -78,8 +78,11 @@ for (const vp of [
   test(`chrome bar keeps every control on screen: ${vp.name}`, async ({ page }) => {
     await page.setViewportSize({ width: vp.width, height: vp.height });
     // Worst realistic content, not whatever the root view happens to show.
+    // Issue #172 grew #position with a search-match suffix, which does not
+    // shrink (flex:0 0 auto; white-space:nowrap) -- so the worst case now
+    // includes it: a search matching every card at the biggest level.
     await page.evaluate(() => {
-      document.querySelector('#position')!.textContent = 'card 124 of 124';
+      document.querySelector('#position')!.textContent = 'card 124 of 124 · 124 results';
       document.querySelector('#connState')!.textContent = 'Bridge :3799';
     });
     const bar = await chromeBar(page);
@@ -1034,6 +1037,94 @@ test('stepping during a search lands on hits, the short way round', async ({ pag
   // alone.
   expect(advances.some(d => d > 1),
     `every step advanced by exactly one card (${advances.join(', ')}) — stepping did not skip the dark cards`).toBe(true);
+});
+
+// Issue #172: with exactly one lit card at a level, the step arrow is a
+// correct, deliberately-tested no-op (nextLitIndex resolves to the card you
+// are already standing on) -- but nothing on screen said so, so a working
+// control read as broken. The #position readout's search suffix is the fix.
+// This test is anchored on real data, verified against this store with a
+// probe script before being written here:
+//   'rolodex' lights exactly 2 of the 20 projects -- 'neurodivergent-memory'
+//   (index 0, the wall's default centered card on a cold load) and the
+//   '(no project)' bucket (index 19, its circular neighbor -- so one
+//   hit-to-hit step reaches it directly). Diving into '(no project)' lands on
+//   its districts level, where the SAME query lights exactly one district,
+//   'logical_analysis', which a fresh dive centers on by default (index 0)
+//   -- the single-hit case the issue is about.
+test('the position readout reports the match count, staying honest through a single-hit level', async ({ page }) => {
+  test.slow();
+  await settleLayout(page);
+
+  await page.locator('#searchInput').fill('rolodex');
+  await page.waitForTimeout(1200); // 250ms debounce + daemon round trip
+
+  const wallText = await page.locator('#position').textContent();
+  expect(wallText, 'the wall should report the 2-project match count')
+    .toMatch(/^card 1 of 20 · 2 results$/);
+
+  // Hit-to-hit stepping (pre-existing, unrelated behaviour) hops from index 0
+  // directly to its only other lit neighbor, index 19.
+  await page.locator('#spinPrev').click();
+  // Poll for the exact expected reading rather than a fixed wait: headless
+  // WebKit's rAF throttling can leave the drum mid-ease for several real
+  // seconds (the neighboring "stepping during a search" test above measured
+  // ~9s for one step), so a flat timeout races it on that engine.
+  await page.waitForFunction(() =>
+    document.querySelector('#position')?.textContent === 'card 20 of 20 · 2 results',
+    null, { timeout: 20_000, polling: 300 });
+  expect(await page.locator('#position').textContent(),
+    'stepping to the other lit project must not change the reported count')
+    .toBe('card 20 of 20 · 2 results');
+
+  // Dive via Enter rather than a centre click: state.frontIndex (and this
+  // readout) flips to the new card the instant the eased rotation crosses the
+  // card boundary, well before the CSS transform finishes visually easing to
+  // its target -- clicking in that window hit-tests against the still-mid-
+  // flight rotation and can land on a different card entirely (observed on
+  // WebKit). dive() reads the front card from state.frontIndex directly, so
+  // it is correct the moment the readout above is, with no such race.
+  // #spinPrev now holds focus, and Enter on a button activates IT instead of
+  // reaching the global dive handler, so focus must move off it first.
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+  await page.keyboard.press('Enter');
+  await page.waitForTimeout(1700); // two ~700ms zoom halves, plus slack
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level))
+    .toBe('districts');
+  expect(await page.locator('#searchInput').inputValue(), 'the query must survive the dive').toBe('rolodex');
+
+  const districtsText = await page.locator('#position').textContent();
+  expect(districtsText, 'a level with exactly one lit card must say so, singular, not "1 results"')
+    .toMatch(/^card 1 of \d+ · 1 result$/);
+
+  // THE property this test exists to pin: the arrow really is a no-op here,
+  // and the readout must keep explaining that rather than going stale or
+  // blank once the (silent, correct, out-of-scope) no-op fires.
+  const before = await page.evaluate(() => (document.querySelector('#drum') as HTMLElement).style.transform);
+  await page.locator('#spinNext').click();
+  await page.waitForTimeout(600);
+  const after = await page.evaluate(() => (document.querySelector('#drum') as HTMLElement).style.transform);
+  expect(after, 'the single lit card is a correct, deliberate no-op — not something this issue changes')
+    .toBe(before);
+  expect(await page.locator('#position').textContent(),
+    'the count must still read "1 result" after the dead-arrow press, not vanish')
+    .toMatch(/^card 1 of \d+ · 1 result$/);
+});
+
+test('the match count disappears the moment the query is cleared', async ({ page }) => {
+  test.slow();
+  await settleLayout(page);
+  await page.locator('#searchInput').fill('rolodex');
+  await page.waitForTimeout(1200);
+  expect(await page.locator('#position').textContent(), 'a precondition: the count must be showing first')
+    .toMatch(/ · 2 results$/);
+
+  await page.locator('#searchInput').fill('');
+  await page.waitForTimeout(600);
+  const cleared = await page.locator('#position').textContent();
+  expect(cleared, 'clearing the query must drop the suffix entirely, not freeze it or show "0 results"')
+    .not.toContain('result');
+  expect(cleared).toMatch(/^card \d+ of 20$/);
 });
 
 // window's contextmenu handler predates the search box and only exempted

--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -912,6 +912,107 @@ test('search dims non-matches without moving a single card', async ({ page }) =>
   expect(await page.evaluate(() => document.querySelectorAll('#drum .card3d.search-dim').length)).toBe(0);
 });
 
+// #crumb keeps its box (visibility:hidden, not display:none) while searching
+// so hiding the coordinate never shrinks #locus -- but #position's
+// search-match suffix (issue #172) can squeeze #crumb into an extra wrapped
+// line while hidden, so its box height is PINNED for the duration of a
+// search rather than left to reflow. A pin computed once, at the moment the
+// search starts, and never revisited would go stale the instant anything
+// changes how many lines #crumb's CURRENT content needs at the CURRENT
+// width -- which a phone rotation does directly (same coordinate, different
+// width). Landscape (~737-852px) is the sharpest case: it misses the 560px
+// media query, so it is already this app's most fragile viewport, and
+// rotating mid-search is an ordinary thing to do while reading.
+//
+// Deliberately NOT a raw before/after card-rect comparison like the test
+// above: at the memories level cardW is `Math.min(560, innerWidth * 0.92)`,
+// so a WIDTH-changing resize legitimately resizes every card regardless of
+// whether the chromeH pin is stale -- a rect comparison here would be
+// confounded by that legitimate resize and could pass or fail for the wrong
+// reason. Asserting on #chrome's own measured height isolates exactly the
+// mechanism the pin exists to hold steady, independent of card geometry.
+test('a search survives a phone rotation without leaving a stale chrome height behind', async ({ page }) => {
+  test.slow();
+  expect(await diveToMemories(page)).toBe('memories');
+
+  await page.setViewportSize({ width: 393, height: 852 }); // portrait
+  await settleLayout(page);
+  await page.locator('#searchInput').fill('memory');
+  await page.waitForTimeout(1200); // 250ms debounce + daemon round trip
+
+  // Rotate to landscape WHILE the search is still active -- the scenario the
+  // pin has to survive.
+  await page.setViewportSize({ width: 852, height: 393 }); // landscape
+  await settleLayout(page); // waits out scheduleResizeRebuild's 200ms debounce too
+
+  const chromeHeightWhileSearching = await page.evaluate(() =>
+    Math.round(document.querySelector('#chrome')!.getBoundingClientRect().height));
+
+  // Ground truth: clear the query at this SAME (landscape) width. #crumb
+  // becomes visible and un-pinned, laying out naturally for the SAME
+  // coordinate at the SAME width -- exactly what the pin is supposed to
+  // have matched all along, whether or not a rotation happened in between.
+  await page.locator('#searchInput').fill('');
+  await page.waitForTimeout(600);
+  const chromeHeightGroundTruth = await page.evaluate(() =>
+    Math.round(document.querySelector('#chrome')!.getBoundingClientRect().height));
+
+  expect(chromeHeightWhileSearching,
+    'the chrome height pinned mid-search at the OLD (portrait) width must match the TRUE height at the NEW (landscape) width -- a stale pin here silently shoves every card down or up')
+    .toBe(chromeHeightGroundTruth);
+});
+
+// Verifies the OTHER half of the pin's "recomputed on every call" claim: a
+// mid-search DIVE, not just a resize, can also change how many lines
+// #crumb's (hidden) coordinate needs -- diving adds segments, at a FIXED
+// width. Reuses the same real navigation path verified in "the position
+// readout reports the match count..." above: 'rolodex' lights '(no
+// project)' at the wall (one hit-to-hit step from the default centred
+// project), and its districts level lights exactly 'logical_analysis'.
+test('a search survives a mid-search dive without leaving a stale chrome height behind', async ({ page }) => {
+  test.slow();
+  await page.setViewportSize({ width: 393, height: 852 });
+  await settleLayout(page);
+
+  await page.locator('#searchInput').fill('rolodex');
+  await page.waitForTimeout(1200); // 250ms debounce + daemon round trip
+
+  await page.locator('#spinPrev').click();
+  await page.waitForFunction(() =>
+    document.querySelector('#position')?.textContent === 'card 20 of 20 · 2 results',
+    null, { timeout: 20_000, polling: 300 });
+
+  // Dive via Enter, not a centre click -- see the single-hit-level test
+  // above for why a click's geometry can race the drum's own easing.
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+  await page.keyboard.press('Enter'); // projects -> districts, centred on the only lit one
+  await page.waitForTimeout(1700);
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level))
+    .toBe('districts');
+
+  await page.keyboard.press('Enter'); // districts -> memories: the deepest, longest coordinate
+  await page.waitForTimeout(1700);
+  expect(await page.evaluate(() => (document.querySelector('#stage') as HTMLElement).dataset.level))
+    .toBe('memories');
+  expect(await page.locator('#searchInput').inputValue(), 'the query must survive both dives').toBe('rolodex');
+
+  const chromeHeightWhileSearching = await page.evaluate(() =>
+    Math.round(document.querySelector('#chrome')!.getBoundingClientRect().height));
+
+  // Ground truth: clear the query at this SAME (post-dive, memories-level)
+  // coordinate and width. If the pin were only recomputed when the SEARCH
+  // ITSELF changes (as the original fix did), it would still be carrying
+  // the wall-level coordinate's height two dives later.
+  await page.locator('#searchInput').fill('');
+  await page.waitForTimeout(600);
+  const chromeHeightGroundTruth = await page.evaluate(() =>
+    Math.round(document.querySelector('#chrome')!.getBoundingClientRect().height));
+
+  expect(chromeHeightWhileSearching,
+    'the chrome height pinned before the two dives must match the TRUE height for the deeper coordinate they landed on')
+    .toBe(chromeHeightGroundTruth);
+});
+
 // The same query means something at every depth: one call, held once,
 // re-interpreted one level deeper each time you dive.
 test('a search at the wall survives a dive and lights the districts inside', async ({ page }) => {

--- a/scripts/nd-mem-rolodex-helpers.mjs
+++ b/scripts/nd-mem-rolodex-helpers.mjs
@@ -747,3 +747,45 @@ export function nextLitIndex(items, hits, snapshot, view, from, direction) {
   }
   return plain;
 }
+
+// ---------- position readout (issue #172) ----------
+// With exactly one lit card, nextLitIndex above correctly resolves to the card
+// you're already standing on and stepBy is a deliberate, tested no-op -- but
+// the app never SAID "there is 1 match and you are on it", so a correct arrow
+// read as a broken one. These two feed the #position readout's search suffix
+// that fixes that.
+
+// How many items AT THE CURRENT LEVEL are lit. Always call with `items` from
+// state.items, never derive this by counting rendered .search-hit elements --
+// the drum only renders a windowed slice of the level (a scalability fix took
+// it from ~3.1k DOM nodes to ~710), so counting the DOM silently undercounts
+// any level bigger than that window.
+export function countLit(items, hits, snapshot, view = {}) {
+  if (!hits || hits.size === 0 || !items || !items.length) return 0;
+  let n = 0;
+  for (const item of items) {
+    if (isLit(item, hits, snapshot, view)) n++;
+  }
+  return n;
+}
+
+// The suffix appended to "card N of M" -- e.g. " · 3 results" or " · 1
+// result" -- or '' when `active` is false, so a plain "card 4 of 20" is
+// untouched with no search running.
+//
+// `active` must be driven by whether a QUERY is set (state.search.query !==
+// ''), never by `count` or hits.size: a query that matches nothing at this
+// level is still an active search and must report "0 results", not silently
+// revert to looking like no search is running.
+//
+// Says "result", not "match": isLit lights a project/district card when
+// something INSIDE it matched, so the card itself is not a match -- it
+// contains one. "N matches" reads true at the memories level (the leaf,
+// where a lit card IS the match) and false everywhere above it, exactly the
+// "implies memory-level counts while standing at the wall" trap the issue
+// calls out. "result" is the one noun that stays honest about a card the
+// query surfaced, whether that card is the match or merely holds one.
+export function positionSearchSuffix(active, count) {
+  if (!active) return '';
+  return ` · ${count} result${count === 1 ? '' : 's'}`;
+}

--- a/scripts/nd-mem-rolodex-helpers.mjs
+++ b/scripts/nd-mem-rolodex-helpers.mjs
@@ -707,27 +707,51 @@ export function parseSearchResults(text) {
 
 // ---------- search lighting ----------
 
+// The ONE place the "which containers hold a hit" rule is expressed. isLit
+// and countLit both go through this (isLit lazily, per call, when it isn't
+// handed a precomputed index; countLit and nextLitIndex build one index up
+// front and reuse it across every item) so the district-scoping rule below
+// cannot drift between a "check one card" path and a "count/scan many cards"
+// path -- there is only one path.
+//
+// Single pass over ALL memories, regardless of how many items are being
+// tested against the result: this is what makes countLit/nextLitIndex
+// O(memories + items) instead of O(items * memories).
+function buildLitIndex(hits, snapshot, view) {
+  const projects = new Set();
+  const districts = new Set();
+  if (!hits || hits.size === 0) return { projects, districts };
+  const memories = Object.values(snapshot?.memories ?? {});
+  // Scoped to the project being viewed. District names are shared across
+  // projects, not globally unique buckets -- without this, standing inside
+  // project beta would light its practical_execution card because something
+  // in ALPHA's practical_execution matched.
+  const scope = view.projectId;
+  for (const m of memories) {
+    if (!hits.has(m.id)) continue;
+    projects.add(projectOf(m));
+    if (scope == null || projectOf(m) === scope) districts.add(districtOf(m));
+  }
+  return { projects, districts };
+}
+
 // One rule at every level: a card is lit if IT, or anything inside it, matched.
 // That is what turns a search into a drill-down -- query at the wall, see which
 // projects light, dive into a lit one, see which districts light -- instead of
 // needing a separate results view.
-export function isLit(item, hits, snapshot, view = {}) {
+//
+// `index`, if given, must come from buildLitIndex(hits, snapshot, view) for
+// this same (hits, snapshot, view) -- callers that test many items against
+// the same search state (countLit, nextLitIndex) build it once and pass it
+// in so the O(memories) pass only happens once, not once per item. Callers
+// that check a single card (e.g. rendering one card's lit state) can omit it
+// and let isLit build its own, at the same per-call cost isLit always had.
+export function isLit(item, hits, snapshot, view = {}, index = null) {
   if (!hits || hits.size === 0 || !item) return false;
   if (item.kind === 'memory') return hits.has(item.id);
-  const memories = Object.values(snapshot?.memories ?? {});
-  if (item.kind === 'project') {
-    return memories.some(m => hits.has(m.id) && projectOf(m) === item.id);
-  }
-  if (item.kind === 'district') {
-    // Scoped to the project being viewed. District names are shared across
-    // projects, not globally unique buckets -- without this, standing inside
-    // project beta would light its practical_execution card because something
-    // in ALPHA's practical_execution matched.
-    const scope = view.projectId;
-    return memories.some(m => hits.has(m.id)
-      && districtOf(m) === item.id
-      && (scope == null || projectOf(m) === scope));
-  }
+  const { projects, districts } = index ?? buildLitIndex(hits, snapshot, view);
+  if (item.kind === 'project') return projects.has(item.id);
+  if (item.kind === 'district') return districts.has(item.id);
   return false;
 }
 
@@ -741,9 +765,10 @@ export function nextLitIndex(items, hits, snapshot, view, from, direction) {
   const step = direction >= 0 ? 1 : -1;
   const plain = ((from + step) % count + count) % count;
   if (!hits || hits.size === 0) return plain;
+  const index = buildLitIndex(hits, snapshot, view);
   for (let i = 1; i <= count; i++) {
     const idx = ((from + step * i) % count + count) % count;
-    if (isLit(items[idx], hits, snapshot, view)) return idx;
+    if (isLit(items[idx], hits, snapshot, view, index)) return idx;
   }
   return plain;
 }
@@ -762,9 +787,15 @@ export function nextLitIndex(items, hits, snapshot, view, from, direction) {
 // any level bigger than that window.
 export function countLit(items, hits, snapshot, view = {}) {
   if (!hits || hits.size === 0 || !items || !items.length) return 0;
+  // Built once, not once per item -- see buildLitIndex's comment. Without
+  // this, countLit is O(items * memories): at 1,768 memories and ~20 items a
+  // level, that is ~35,000 isLit-internal iterations plus twenty Object.values
+  // allocations per updateChrome() call, and updateChrome runs on every
+  // front-card change while a search is active.
+  const index = buildLitIndex(hits, snapshot, view);
   let n = 0;
   for (const item of items) {
-    if (isLit(item, hits, snapshot, view)) n++;
+    if (isLit(item, hits, snapshot, view, index)) n++;
   }
   return n;
 }

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -916,7 +916,14 @@
       // lone depth badge and the band would read "⌂ 0^0" and nothing else.
       if (segs.length <= 1) els.crumb.innerHTML += '<span class="sep">·</span><span class="seg leaf">All projects</span>';
       els.crumb.dataset.segments = JSON.stringify(segs.map(s => s.target));
-      els.position.textContent = state.items.length ? `card ${state.frontIndex + 1} of ${state.items.length}` : '—';
+      // `state.search.query` (not hits.size) is the "is a search active" flag:
+      // a query that matches nothing AT ALL still leaves hits empty, and that
+      // must still report "0 results" rather than silently look unsearched.
+      const searching = state.search.query !== '';
+      const litCount = searching ? H.countLit(state.items, state.search.hits, state.snapshot, state.view) : 0;
+      els.position.textContent = state.items.length
+        ? `card ${state.frontIndex + 1} of ${state.items.length}${H.positionSearchSuffix(searching, litCount)}`
+        : '—';
       els.hudHint.textContent = H.hintFor(level, POINTER_KIND);
       // One card cannot be stepped between, and a lone ◀ ▶ pair implies it can.
       els.spin.classList.toggle('hidden', state.items.length < 2);
@@ -1794,7 +1801,7 @@
     let searchSeq = 0;
     async function runSearch(query){
       const seq = ++searchSeq;
-      if (!query) { state.search = { query: '', hits: new Map() }; renderSearchState(); return; }
+      if (!query) { state.search = { query: '', hits: new Map() }; renderSearchState(); updateChrome(); return; }
       // A failed search and a search that matched nothing both arrive as an
       // empty hit set, and both would render as "every card dimmed" if we let
       // them -- so a dead daemon, a stale bridge, or a store that refuses to
@@ -1841,10 +1848,35 @@
       if (!data.ok) { showToast('Search failed — the drum is unchanged.'); return; }
       state.search = { query, hits: new Map((data.hits || []).map(h => [h.id, h.score])) };
       renderSearchState();
+      updateChrome();
     }
     els.searchInput.addEventListener('input', () => {
       const q = els.searchInput.value.trim();
-      els.locus.classList.toggle('searching', q !== '');
+      const nowSearching = q !== '';
+      const wasSearching = els.locus.classList.contains('searching');
+      if (nowSearching && !wasSearching) {
+        // #crumb keeps its box (visibility:hidden, not display:none) while
+        // searching, precisely so hiding the coordinate never shrinks #locus
+        // -- see that rule's own comment. But #crumb's box HEIGHT is driven
+        // by how many lines its content wraps to, and that wrap is sensitive
+        // to how much row width its sibling #position currently takes.
+        // #position's search-match suffix (issue #172) widens it the moment
+        // a query lands, leaving #crumb less room and pushing it onto an
+        // extra wrapped line WHILE HIDDEN -- silently growing #locus,
+        // #chrome, and therefore --chromeH, and shoving every card down
+        // (caught by "search dims... without moving a single card" on
+        // mobile-safari at a deep coordinate). Pinning #crumb's height for
+        // the duration of the search holds #chrome's height steady
+        // regardless of what #position or a mid-search dive later do to
+        // crumb's own wrap -- content can clip inside it, which is
+        // invisible, since crumb itself is.
+        els.crumb.style.height = els.crumb.getBoundingClientRect().height + 'px';
+        els.crumb.style.overflow = 'hidden';
+      } else if (!nowSearching && wasSearching) {
+        els.crumb.style.height = '';
+        els.crumb.style.overflow = '';
+      }
+      els.locus.classList.toggle('searching', nowSearching);
       clearTimeout(searchTimer);
       searchTimer = setTimeout(() => runSearch(q), 250);
     });

--- a/scripts/nd-mem-rolodex.html
+++ b/scripts/nd-mem-rolodex.html
@@ -921,9 +921,42 @@
       // must still report "0 results" rather than silently look unsearched.
       const searching = state.search.query !== '';
       const litCount = searching ? H.countLit(state.items, state.search.hits, state.snapshot, state.view) : 0;
-      els.position.textContent = state.items.length
-        ? `card ${state.frontIndex + 1} of ${state.items.length}${H.positionSearchSuffix(searching, litCount)}`
-        : '—';
+      const baseText = state.items.length ? `card ${state.frontIndex + 1} of ${state.items.length}` : '—';
+      // #crumb keeps its box (visibility:hidden, not display:none) while
+      // searching -- see that CSS rule's own comment -- so hiding the
+      // coordinate never shrinks #locus. But #crumb's box HEIGHT is driven by
+      // how many lines its content wraps to, which is sensitive to how much
+      // row width its sibling #position currently takes, and #position's
+      // search-match suffix widens it the instant a query lands.
+      //
+      // Pinning #crumb's height ONCE, at the moment a query starts, does not
+      // survive anything that can change how many lines #crumb's CURRENT
+      // content needs at the CURRENT width -- a resize/rotation (the same
+      // coordinate needs a different wrap at a different width) or a dive
+      // mid-search (a longer coordinate needs more lines at the same width).
+      // Both land here: buildDrum()/updateFrontCard() call this on every
+      // resize-rebuild and every dive, so recomputing the pin on EVERY call
+      // (rather than once, at search-start) keeps it correct through both,
+      // with no separate resize listener needed.
+      //
+      // The measurement is taken against `baseText` -- #position's content
+      // WITHOUT the suffix -- not the actual (wider, suffixed) text about to
+      // be written below. That is what makes the pinned height match what
+      // #crumb already had a moment before this search existed: measuring
+      // against the real, suffixed #position would let the suffix's own
+      // width keep squeezing #crumb, which is exactly the bug this exists to
+      // prevent, just reintroduced one line later.
+      if (searching) {
+        els.crumb.style.height = '';
+        els.crumb.style.overflow = '';
+        els.position.textContent = baseText; // measure at the UNSUFFIXED width
+        els.crumb.style.height = els.crumb.getBoundingClientRect().height + 'px';
+        els.crumb.style.overflow = 'hidden';
+      } else {
+        els.crumb.style.height = '';
+        els.crumb.style.overflow = '';
+      }
+      els.position.textContent = state.items.length ? `${baseText}${H.positionSearchSuffix(searching, litCount)}` : '—';
       els.hudHint.textContent = H.hintFor(level, POINTER_KIND);
       // One card cannot be stepped between, and a lone ◀ ▶ pair implies it can.
       els.spin.classList.toggle('hidden', state.items.length < 2);
@@ -1854,25 +1887,17 @@
       const q = els.searchInput.value.trim();
       const nowSearching = q !== '';
       const wasSearching = els.locus.classList.contains('searching');
-      if (nowSearching && !wasSearching) {
-        // #crumb keeps its box (visibility:hidden, not display:none) while
-        // searching, precisely so hiding the coordinate never shrinks #locus
-        // -- see that rule's own comment. But #crumb's box HEIGHT is driven
-        // by how many lines its content wraps to, and that wrap is sensitive
-        // to how much row width its sibling #position currently takes.
-        // #position's search-match suffix (issue #172) widens it the moment
-        // a query lands, leaving #crumb less room and pushing it onto an
-        // extra wrapped line WHILE HIDDEN -- silently growing #locus,
-        // #chrome, and therefore --chromeH, and shoving every card down
-        // (caught by "search dims... without moving a single card" on
-        // mobile-safari at a deep coordinate). Pinning #crumb's height for
-        // the duration of the search holds #chrome's height steady
-        // regardless of what #position or a mid-search dive later do to
-        // crumb's own wrap -- content can clip inside it, which is
-        // invisible, since crumb itself is.
-        els.crumb.style.height = els.crumb.getBoundingClientRect().height + 'px';
-        els.crumb.style.overflow = 'hidden';
-      } else if (!nowSearching && wasSearching) {
+      // #crumb's height-pin itself is applied/recomputed entirely inside
+      // updateChrome (see its own comment) -- it runs in the same
+      // synchronous call that widens #position with the search suffix, so
+      // there is no window where the squeeze exists but the pin hasn't
+      // caught up. Clearing it is handled here too, though, and
+      // synchronously: `.searching` (toggled below) makes #crumb VISIBLE
+      // again immediately, but updateChrome only runs 250ms later via the
+      // debounced runSearch(''). Without this, #crumb would render visible
+      // but still clipped to its last frozen height for that quarter
+      // second.
+      if (!nowSearching && wasSearching) {
         els.crumb.style.height = '';
         els.crumb.style.overflow = '';
       }

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -981,6 +981,86 @@ test('countLit handles the single-hit case the user actually hit', () => {
   assert.equal(countLit(items, new Map([['mem_2', 0.9]]), SNAP, WALL), 1);
 });
 
+// ---------- countLit / isLit equivalence (perf fix, PR #174 review) ----------
+// countLit used to call isLit per item, and isLit rebuilt Object.values(
+// snapshot.memories) on every call -- O(items * memories) per updateChrome()
+// during a spin. The fix routes both through one internal index built once
+// per countLit call. This block pins that countLit must stay EXACTLY
+// equivalent to counting isLit over the same items, across every level and
+// several hit-set shapes, so the fast path can never silently drift from the
+// per-item definition of "lit".
+function assertCountLitMatchesIsLit(items, hits, snapshot, view, label) {
+  const expected = items.filter(i => isLit(i, hits, snapshot, view)).length;
+  assert.equal(countLit(items, hits, snapshot, view), expected,
+    `${label}: countLit=${countLit(items, hits, snapshot, view)} expected=${expected}`);
+}
+
+test('countLit === isLit-per-item at the projects level', () => {
+  const items = [
+    { id: 'alpha', kind: 'project' },
+    { id: 'beta', kind: 'project' },
+    { id: UNASSIGNED, kind: 'project' },
+  ];
+  // Hits spanning alpha, beta, and neither.
+  assertCountLitMatchesIsLit(items,
+    new Map([['mem_1', 0.9], ['mem_4', 0.5]]), SNAP, WALL, 'projects, multi-hit');
+});
+
+test('countLit === isLit-per-item at the districts level, scoped to two different projects', () => {
+  // THE case the finding calls out: a hit in alpha's practical_execution must
+  // not light a same-named or differently-named district card while standing
+  // in beta, and countLit's batch index must respect that exactly as isLit
+  // does per item.
+  const itemsInAlpha = [
+    { id: 'practical_execution', kind: 'district' },
+    { id: 'vigilant_monitoring', kind: 'district' },
+  ];
+  const itemsInBeta = [
+    { id: 'practical_execution', kind: 'district' }, // beta has no such district for real, but the card shape is still checkable
+    { id: 'logical_analysis', kind: 'district' },
+    { id: 'weird_custom', kind: 'district' },
+  ];
+  // Hits: mem_1 (alpha/practical_execution) and mem_6 (beta/logical_analysis).
+  const hits = new Map([['mem_1', 0.9], ['mem_6', 0.4]]);
+  const IN_BETA = { level: 'districts', projectId: 'beta', districtId: null };
+  assertCountLitMatchesIsLit(itemsInAlpha, hits, SNAP, IN_ALPHA, 'districts, in alpha');
+  assertCountLitMatchesIsLit(itemsInBeta, hits, SNAP, IN_BETA, 'districts, in beta');
+  // Pin the actual scoped answer too, not just internal agreement: alpha's
+  // hit must not leak into beta's identically-named district card.
+  assert.equal(countLit(itemsInBeta, hits, SNAP, IN_BETA), 1);
+  assert.equal(isLit(itemsInBeta[0], hits, SNAP, IN_BETA), false);
+});
+
+test('countLit === isLit-per-item at the memories level', () => {
+  const items = [
+    { id: 'mem_1', kind: 'memory' },
+    { id: 'mem_2', kind: 'memory' },
+    { id: 'mem_3', kind: 'memory' },
+    { id: 'mem_4', kind: 'memory' },
+  ];
+  assertCountLitMatchesIsLit(items,
+    new Map([['mem_1', 0.9], ['mem_3', 0.4]]), SNAP, WALL, 'memories, multi-hit');
+});
+
+test('countLit === isLit-per-item with an empty hit set', () => {
+  const projectItems = [{ id: 'alpha', kind: 'project' }, { id: 'beta', kind: 'project' }];
+  const districtItems = [{ id: 'practical_execution', kind: 'district' }, { id: 'vigilant_monitoring', kind: 'district' }];
+  const memoryItems = [{ id: 'mem_1', kind: 'memory' }, { id: 'mem_2', kind: 'memory' }];
+  const none = new Map();
+  assertCountLitMatchesIsLit(projectItems, none, SNAP, WALL, 'projects, empty hits');
+  assertCountLitMatchesIsLit(districtItems, none, SNAP, IN_ALPHA, 'districts, empty hits');
+  assertCountLitMatchesIsLit(memoryItems, none, SNAP, WALL, 'memories, empty hits');
+});
+
+test('countLit === isLit-per-item with a hit set matching nothing at this level', () => {
+  const projectItems = [{ id: 'alpha', kind: 'project' }, { id: 'beta', kind: 'project' }];
+  const districtItems = [{ id: 'practical_execution', kind: 'district' }, { id: 'vigilant_monitoring', kind: 'district' }];
+  // mem_99 does not exist in SNAP at all -- hits non-empty, but nothing lands.
+  const hits = new Map([['mem_99', 0.9]]);
+  assertCountLitMatchesIsLit(projectItems, hits, SNAP, WALL, 'projects, no-match hits');
+  assertCountLitMatchesIsLit(districtItems, hits, SNAP, IN_ALPHA, 'districts, no-match hits');
+});
+
 test('positionSearchSuffix is blank when no search is active', () => {
   assert.equal(positionSearchSuffix(false, 0), '');
   // Even a nonzero count must not leak through if the caller says inactive --

--- a/test/rolodex-helpers.test.mjs
+++ b/test/rolodex-helpers.test.mjs
@@ -14,7 +14,7 @@ import {
   hintFor,
   truncateNodeLabel, MINIMAP_COL,
   parseSearchResults,
-  isLit, nextLitIndex,
+  isLit, nextLitIndex, countLit, positionSearchSuffix,
 } from '../scripts/nd-mem-rolodex-helpers.mjs';
 
 // Fixture: alpha has 3 memories in 2 districts, beta has 2 (one custom district),
@@ -933,4 +933,65 @@ test('nextLitIndex falls back to ordinary stepping when hits exist but none land
   const hits = new Map([['mem_99', 0.9]]);
   assert.equal(nextLitIndex(items, hits, SNAP, WALL, 0, 1), 1);
   assert.equal(nextLitIndex(items, hits, SNAP, WALL, 0, -1), 2);
+});
+
+// ---------- countLit / positionSearchSuffix (issue #172) ----------
+// The #position readout ("card 4 of 20 · 3 results") that tells a user why an
+// arrow just went dead: with exactly one lit card, nextLitIndex correctly
+// resolves to the card you are already standing on, and the arrow is a
+// deliberate no-op -- but nothing said so. These cover the count these two
+// functions feed that readout.
+
+test('countLit counts projects that contain a hit, not memories', () => {
+  // alpha has 3 memories; only mem_1 and mem_3 match. countLit must still say
+  // 1 (one PROJECT card is lit), not 2 -- the count is over items at THIS
+  // level, never over how many memories matched underneath it.
+  const items = [
+    { id: 'alpha', kind: 'project' },
+    { id: 'beta', kind: 'project' },
+  ];
+  const hits = new Map([['mem_1', 0.9], ['mem_3', 0.4]]);
+  assert.equal(countLit(items, hits, SNAP, WALL), 1);
+});
+
+test('countLit counts every lit memory at the leaf level', () => {
+  const items = [
+    { id: 'mem_1', kind: 'memory' },
+    { id: 'mem_2', kind: 'memory' },
+    { id: 'mem_3', kind: 'memory' },
+  ];
+  const hits = new Map([['mem_1', 0.9], ['mem_3', 0.4]]);
+  assert.equal(countLit(items, hits, SNAP, WALL), 2);
+});
+
+test('countLit is 0 with no hits, and 0 when hits exist but none land at this level', () => {
+  const items = [{ id: 'mem_1', kind: 'memory' }, { id: 'mem_2', kind: 'memory' }];
+  assert.equal(countLit(items, new Map(), SNAP, WALL), 0);
+  assert.equal(countLit(items, new Map([['mem_99', 0.9]]), SNAP, WALL), 0);
+});
+
+test('countLit handles the single-hit case the user actually hit', () => {
+  // Exactly one lit card at this level -- the case where stepBy's early return
+  // (target === state.frontIndex) makes the arrow a correct, silent no-op.
+  const items = [
+    { id: 'mem_1', kind: 'memory' },
+    { id: 'mem_2', kind: 'memory' },
+    { id: 'mem_3', kind: 'memory' },
+  ];
+  assert.equal(countLit(items, new Map([['mem_2', 0.9]]), SNAP, WALL), 1);
+});
+
+test('positionSearchSuffix is blank when no search is active', () => {
+  assert.equal(positionSearchSuffix(false, 0), '');
+  // Even a nonzero count must not leak through if the caller says inactive --
+  // this is what keeps the suffix from a prior query surviving a clear.
+  assert.equal(positionSearchSuffix(false, 3), '');
+});
+
+test('positionSearchSuffix pluralizes correctly, singular vs plural vs zero', () => {
+  assert.equal(positionSearchSuffix(true, 1), ' · 1 result');
+  assert.equal(positionSearchSuffix(true, 3), ' · 3 results');
+  // A query that matches nothing AT THIS LEVEL is still an active search and
+  // must say so, not silently fall back to the unsearched reading.
+  assert.equal(positionSearchSuffix(true, 0), ' · 0 results');
 });


### PR DESCRIPTION
Closes #172.

Found in use, right after #170 merged: with exactly one lit card at a level, the spin arrow appears dead. Centred on the only match it does nothing; drag away and it snaps straight back.

That behaviour is correct and unit-tested — `nextLitIndex` resolves to the single hit from anywhere, and `stepBy` returns early when the target is already the front card. The problem is that it is **silent**. The app knows "there is 1 result and you are standing on it" and says none of it, so a working control reads as a broken one.

## The fix

Extend the existing `#position` readout while a search is active:

```
no search:   card 4 of 20
searching:   card 4 of 20 · 3 results
single hit:  card 4 of 20 · 1 result
```

Two wording decisions that are load-bearing rather than cosmetic:

**"result", not "match".** `isLit` lights a project or district card when something *inside* it matched, so above the leaf the card is not a match — it contains one. "3 matches" reads true at the memories level and lies everywhere above it.

**Driven by whether a query is set, not by whether hits exist.** A query that matches nothing at this level is still an active search and reports `0 results`, rather than silently reverting to looking unsearched.

Counting happens over `state.items` via `H.isLit`, never over the DOM: the drum renders only a windowed slice (~3.1k nodes down to ~710), so counting `.search-hit` elements would undercount exactly the large levels where the count matters most.

## Two layout bugs found on the way

Both are the same coupling — `#stage` is inset by `--chromeH`, which is measured from `#chrome`, so anything that changes the chrome bar's height moves every card. `#crumb` keeps its box while searching (`visibility:hidden`, not `display:none`) precisely so hiding the coordinate cannot shrink the row — but its box *height* still depends on how many lines its content wraps to.

1. **The suffix's own width** left `#crumb` less room, pushing it onto an extra wrapped line **while invisible**, growing `--chromeH` and shoving every card down — exactly what "search dims, never moves a card" exists to prevent. Caught by the existing spec on mobile Safari at a deep coordinate.
2. **A stale pin.** The first fix pinned `#crumb`'s height once, when the search began. That does not survive anything changing how many lines the *current* content needs at the *current* width — a rotation, or a mid-search dive to a longer coordinate. Verified rather than assumed: the dive case was independently broken too.

The pin is now recomputed inside `updateChrome`, measured against `#position`'s **unsuffixed** text. Measuring against the real suffixed text would let the suffix squeeze the crumb again, reintroducing bug 1 one line later.

That measurement forces a synchronous layout, but only on real front-card changes, dives, rebuilds and query land/clear — `updateFrontCard` early-returns when the index has not moved, and the rAF loop never reaches it.

## Testing

| suite | before | after |
|---|---|---|
| `npm test` | 318 / 316 pass / 2 known | **324 / 322 pass / 2 known** |
| `npx playwright test` | 73 passed / 1 skipped | **81 passed / 1 skipped** |

The 2 `npm test` failures are pre-existing wording drift in `test/agent-customization-wording.test.mjs`, unrelated. The 1 skip is the pre-existing desktop-only wheel guard.

Four new browser specs, each proven RED before GREEN on both engines. The `chrome bar keeps every control on screen` guard was re-run after the pin change: **10/10**, five viewports × two projects.

## Note for CI

`stepping during a search lands on hits, the short way round` fails roughly 1 run in 3 on `mobile-safari`. It is **pre-existing** — measured on unmodified `development`, and tracked in #173. If a run here goes red on that spec alone, it is not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
