### PR TITLE
fix(bridge): exit when the port is held, and shut down cleanly on a signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,22 @@ Running locally on the development branch; not part of a release cut (version st
 
 ### Fixed
 
+- **The bridge no longer stays alive when it cannot bind its port.** It registered no
+  `listen` error handler, so a second bridge lost the bind, printed nothing, and kept
+  running — with no `SIGINT`/`SIGTERM` handlers either, and closing a terminal on Windows
+  orphaning the child rather than killing it, these accumulated. A five-day-old bridge
+  therefore still owned port 3737 and answered `/health` with `200` from code that predated
+  the `/search` route, so the page's search 404'd while every check said "running" and
+  restarting appeared not to help. The bridge now exits 1 and names the process holding the
+  port, tears down cleanly on `SIGINT`/`SIGTERM` (closing the server, clearing the poll
+  timer, and ending open SSE streams that would otherwise hold it open — the shared daemon
+  is deliberately left running), and ships `npm run bridge` / `npm run bridge:stop`, which
+  stops by port ownership rather than a remembered pid.
+- **The bridge announced success on a failed start.** On Windows the `listen` callback fires
+  even when the bind loses — the dual-stack IPv6 bind fails a tick later — so the startup
+  banner printed `{"ok":true,...}` and `--open` launched a browser onto the *old* bridge
+  holding the port, confirming the wrong conclusion. Success is now gated on
+  `server.address()`, which is `null` in that callback.
 - `scripts/nd-mem-bridge-server.mjs` resolved its HTML/helpers/daemon-entry paths off
   `process.cwd()` instead of its own file location, so launching it via absolute path
   from any directory other than the repo root 404'd with "Bridge UI not found". Now

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ For visually browsing, creating, editing, and reorganizing memories outside of a
 Start it (works from any directory once dependencies are installed):
 
 ```bash
-node scripts/nd-mem-bridge-server.mjs
+npm run bridge
 ```
 
 Then open **`http://localhost:3737/`** in a browser — or let the bridge open it for you:
@@ -732,6 +732,24 @@ With no flag, an interactive terminal asks `Open bridge UI at http://localhost:3
 > **Important:** Open the URL above, not the `.html` file directly. Loading `nd-mem-mcp-app-bridge.html` via `file://` (double-clicking it, or "Open File" in a browser) silently breaks the page's helper-module import — the page still loads, but project rename/merge fails with a misleading "helpers not loaded" error even though the bridge is running.
 
 The web app polls the memory snapshot for external changes and pushes live updates over server-sent events, and supports renaming a project across all its memories, merging into an existing project on a name collision, and a "did you mean" prompt for near-miss project names.
+
+Stop it with `Ctrl+C`, or from anywhere:
+
+```bash
+npm run bridge:stop
+```
+
+`bridge:stop` finds the process by **port ownership**, not by a pid you wrote
+down — the pid you remember is not necessarily the one holding the port. It
+refuses to kill a process that does not answer `/health` the way the bridge
+does (pass `--force` to override), and reports success when nothing is running.
+
+If the port is already taken, the bridge now **exits instead of starting**, and
+names the process holding it. It used to stay alive without listening, which
+looked healthy to every check while serving nothing — closing a terminal on
+Windows orphans the child rather than killing it, so a months-old bridge could
+still own port 3737 and answer `/health` from a version of the code that
+predates the routes your page is asking for.
 
 Configuration (all optional):
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "package:vscode": "npm run build && node scripts/package-vscode-extension.cjs",
     "prepack": "node scripts/prepare-agent-kit.cjs",
     "sync-memories": "npm run build && node build/scripts/sync-memories.js",
+    "bridge": "node scripts/nd-mem-bridge-server.mjs",
+    "bridge:stop": "node scripts/nd-mem-bridge-stop.mjs",
     "lint": "npm run lint:code && npm run lint:md",
     "lint:code": "tsc --noEmit",
     "lint:md": "npx --yes markdownlint-cli --config .markdownlint.json README.md CHANGELOG.md CONTRIBUTING.md CODE_OF_CONDUCT.md SECURITY.md SUPPORT.md TEST_SUMMARY.md SMOKE_TEST_REPORT.md",

--- a/scripts/nd-mem-bridge-lifecycle.mjs
+++ b/scripts/nd-mem-bridge-lifecycle.mjs
@@ -49,7 +49,7 @@ function run(execFileImpl, cmd, args) {
  * address ends in the port we asked about, and the foreign address is the
  * wildcard. That holds in every locale.
  */
-function parseNetstat(stdout, port) {
+export function parseNetstat(stdout, port) {
   const owners = [];
   for (const line of stdout.split(/\r?\n/)) {
     const cols = line.trim().split(/\s+/);
@@ -81,7 +81,12 @@ export async function findPortOwners(port, options = {}) {
   const { execFileImpl = nodeExecFile, platform = process.platform } = options;
 
   if (platform === 'win32') {
-    const stdout = await run(execFileImpl, 'netstat', ['-ano', '-p', 'TCP']);
+    // NOT `-p TCP`: that selects the IPv4 table only, and an IPv6 listener is
+    // then invisible — which made this return [] while a bridge held the port,
+    // and made bridge:stop announce "nothing to stop". Node resolves localhost
+    // to ::1 first, so IPv6-only listeners are ordinary, not exotic. Plain
+    // -ano lists every table; parseNetstat filters by row shape.
+    const stdout = await run(execFileImpl, 'netstat', ['-ano']);
     return [...new Set(parseNetstat(stdout, port))];
   }
 
@@ -94,8 +99,10 @@ export async function findPortOwners(port, options = {}) {
   const owners = [];
   for (const line of ss.split(/\r?\n/)) {
     if (!new RegExp(`[:.]${port}\\s`).test(line)) continue;
-    const match = line.match(/pid=(\d+)/);
-    if (match) owners.push(Number(match[1]));
+    // One row can name several pids — SO_REUSEPORT siblings appear as
+    // users:(("node",pid=123,fd=20),("node",pid=456,fd=21)). Taking only the
+    // first would leave a holder alive and the port still busy.
+    for (const match of line.matchAll(/pid=(\d+)/g)) owners.push(Number(match[1]));
   }
   return [...new Set(owners)];
 }

--- a/scripts/nd-mem-bridge-lifecycle.mjs
+++ b/scripts/nd-mem-bridge-lifecycle.mjs
@@ -20,6 +20,27 @@ import { execFile as nodeExecFile } from 'child_process';
 
 const LOOKUP_TIMEOUT_MS = 4000;
 
+/**
+ * Parse a port from configuration, or throw naming the setting at fault.
+ *
+ * Number('abc') is NaN, and NOTHING CAN EVER BE LISTENING ON NaN — so an
+ * unvalidated port turns every ownership lookup into an empty result, and
+ * bridge:stop would announce "nothing to stop" and exit 0 for a run that never
+ * checked anything. A misconfigured port must not read as a clean machine.
+ * Shared so both scripts fail the same way, and so neither reports a state it
+ * did not verify.
+ */
+export function resolvePort(raw, fallback, settingName = 'ND_MEM_BRIDGE_PORT') {
+  if (raw === undefined || raw === '') return fallback;
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(
+      `${settingName}=${raw} is not a usable port. Expected a whole number between 1 and 65535.`,
+    );
+  }
+  return port;
+}
+
 /** The command that answers "who holds this port", for a human to run. */
 export function portOwnerCommand(port, platform = process.platform) {
   return platform === 'win32'

--- a/scripts/nd-mem-bridge-lifecycle.mjs
+++ b/scripts/nd-mem-bridge-lifecycle.mjs
@@ -1,0 +1,191 @@
+import { execFile as nodeExecFile } from 'child_process';
+
+/**
+ * Port ownership and orderly shutdown for the bridge.
+ *
+ * Both halves exist because of one incident (2026-08-02): the rolodex reported
+ * "Search could not reach the bridge" while a bridge was demonstrably running.
+ * Port 3737 was held by a bridge started five days before the /search route was
+ * written. Restarting did not help — the relaunched processes COULD NOT BIND
+ * AND STAYED ALIVE ANYWAY, so every signal the user had (a live process,
+ * /health answering 200) pointed at their network instead of their process
+ * list. A process that is running but not listening is worse than one that
+ * died.
+ *
+ * Kept in its own module so the wiring can be tested with fakes. Signals are
+ * not deliverable to a child process on Windows — child.kill('SIGTERM') is
+ * TerminateProcess and no handler runs — so a spawn-and-signal test would have
+ * to skip on the exact platform this incident happened on.
+ */
+
+const LOOKUP_TIMEOUT_MS = 4000;
+
+/** The command that answers "who holds this port", for a human to run. */
+export function portOwnerCommand(port, platform = process.platform) {
+  return platform === 'win32'
+    ? `Get-NetTCPConnection -LocalPort ${port} -State Listen | Select -Expand OwningProcess -Unique`
+    : `lsof -nP -iTCP:${port} -sTCP:LISTEN`;
+}
+
+function run(execFileImpl, cmd, args) {
+  return new Promise((resolve) => {
+    try {
+      execFileImpl(cmd, args, { timeout: LOOKUP_TIMEOUT_MS, maxBuffer: 1 << 24 }, (error, stdout) => {
+        // A non-zero exit is normal here: lsof exits 1 when nothing matches.
+        resolve(error && !stdout ? '' : String(stdout || ''));
+      });
+    } catch {
+      resolve('');
+    }
+  });
+}
+
+/**
+ * Windows `netstat -ano -p TCP` rows look like:
+ *   TCP    0.0.0.0:3737    0.0.0.0:0    LISTENING    47640
+ *
+ * The state word is localised on non-English Windows, so it is deliberately not
+ * matched. A listening socket is identified by its shape instead: the local
+ * address ends in the port we asked about, and the foreign address is the
+ * wildcard. That holds in every locale.
+ */
+function parseNetstat(stdout, port) {
+  const owners = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const cols = line.trim().split(/\s+/);
+    if (cols.length < 5) continue;
+    const [proto, local, foreign, , pid] = cols;
+    if (!/^TCP/i.test(proto)) continue;
+    if (!local.endsWith(`:${port}`)) continue;
+    if (!/^(0\.0\.0\.0|\[::\]|\*):0$/.test(foreign)) continue;
+    const numeric = Number(pid);
+    if (Number.isInteger(numeric) && numeric > 0) owners.push(numeric);
+  }
+  return owners;
+}
+
+function parsePids(stdout) {
+  return stdout
+    .split(/\s+/)
+    .map((token) => Number(token))
+    .filter((pid) => Number.isInteger(pid) && pid > 0);
+}
+
+/**
+ * Best-effort list of pids listening on `port`. Returns [] rather than throwing
+ * on any failure: this runs inside the error path of a startup failure, and a
+ * crash there would replace a useful message with a useless one. "Port is in
+ * use, owner unknown" is still worth printing.
+ */
+export async function findPortOwners(port, options = {}) {
+  const { execFileImpl = nodeExecFile, platform = process.platform } = options;
+
+  if (platform === 'win32') {
+    const stdout = await run(execFileImpl, 'netstat', ['-ano', '-p', 'TCP']);
+    return [...new Set(parseNetstat(stdout, port))];
+  }
+
+  const lsof = await run(execFileImpl, 'lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t']);
+  const fromLsof = [...new Set(parsePids(lsof))];
+  if (fromLsof.length > 0) return fromLsof;
+
+  // Containers and slim images routinely ship without lsof.
+  const ss = await run(execFileImpl, 'ss', ['-ltnp']);
+  const owners = [];
+  for (const line of ss.split(/\r?\n/)) {
+    if (!new RegExp(`[:.]${port}\\s`).test(line)) continue;
+    const match = line.match(/pid=(\d+)/);
+    if (match) owners.push(Number(match[1]));
+  }
+  return [...new Set(owners)];
+}
+
+/**
+ * The message printed when the bridge cannot bind. This message is the fix:
+ * had the relaunch said "port 3737 is already held by pid 47640", the incident
+ * above would have ended in one line instead of an afternoon.
+ */
+export function describePortConflict(port, owners, platform = process.platform) {
+  const held = owners.length === 1
+    ? `held by pid ${owners[0]}`
+    : owners.length > 1
+      ? `held by pids ${owners.join(', ')}`
+      : 'held by a process this bridge could not identify';
+
+  return [
+    `Bridge: FATAL — port ${port} is already in use, ${held}.`,
+    'This bridge is exiting rather than staying alive without listening.',
+    owners.length > 0
+      ? 'The holder may be an OLDER bridge: /health answers 200 from it while newer routes 404. '
+        + 'Stop it with `npm run bridge:stop`, or start this one elsewhere with ND_MEM_BRIDGE_PORT.'
+      : `Find the owner with: ${portOwnerCommand(port, platform)}`,
+  ].join('\n');
+}
+
+/**
+ * Register SIGINT/SIGTERM teardown and return the `shutdown` it installs.
+ *
+ * NOTE FOR ANYONE TEMPTED TO DELETE THIS AGAIN. An earlier version of the
+ * bridge had a signal block, and the single-writer migration
+ * (docs/superpowers/plans/2026-07-13-single-writer-daemon.md) deleted it with
+ * the note "there is no child to kill — the daemon deliberately outlives the
+ * bridge". That is still true, and it is still not a reason to have no
+ * handlers: the poll interval, the open SSE responses, and the listening socket
+ * all outlive the bridge too if nothing tears them down. THIS HANDLER MUST NOT
+ * STOP THE DAEMON — the daemon is shared, and other clients are using it.
+ *
+ * @param {object} o
+ * @param {{close: Function}} o.server           listening server to close
+ * @param {Array} o.timers                       intervals to clear
+ * @param {Set} o.clients                        open SSE responses to end
+ * @param {import('events').EventEmitter} [o.emitter]  signal source (default: process)
+ * @param {(code: number) => void} [o.onExit]    exit hook (default: process.exit)
+ * @param {number} [o.forceExitMs]               deadline for server.close()
+ */
+export function installLifecycle(options) {
+  const {
+    server,
+    timers = [],
+    clients = new Set(),
+    emitter = process,
+    signals = ['SIGINT', 'SIGTERM'],
+    onExit = (code) => process.exit(code),
+    log = (message) => console.error(message),
+    forceExitMs = 5000,
+  } = options;
+
+  let shuttingDown = false;
+
+  function shutdown(signal) {
+    // Ctrl+C twice, or a signal arriving mid-teardown, must not re-enter: the
+    // second pass would close an already-closing server and exit twice.
+    if (shuttingDown) return;
+    shuttingDown = true;
+    log(`Bridge: ${signal} received — shutting down.`);
+
+    for (const timer of timers) clearInterval(timer);
+
+    // server.close() waits for open connections to drain, and an SSE stream
+    // never drains on its own — every connected phone would hold the bridge
+    // open indefinitely. End them first, then close.
+    for (const client of clients) {
+      try { client.end(); } catch { /* the socket is already gone; keep going */ }
+    }
+    clients.clear();
+
+    const deadline = setTimeout(() => {
+      log('Bridge: connections did not close in time — exiting anyway.');
+      onExit(1);
+    }, forceExitMs);
+    deadline.unref?.();
+
+    server.close(() => {
+      clearTimeout(deadline);
+      onExit(0);
+    });
+  }
+
+  for (const signal of signals) emitter.on(signal, () => shutdown(signal));
+
+  return { shutdown };
+}

--- a/scripts/nd-mem-bridge-server.mjs
+++ b/scripts/nd-mem-bridge-server.mjs
@@ -9,6 +9,7 @@ import * as readline from 'readline';
 import { ensureDaemon } from '../build/core/ensure-daemon.js';
 import { resolveDaemonPort } from '../build/core/run-mode.js';
 import { parseSearchResults } from './nd-mem-rolodex-helpers.mjs';
+import { findPortOwners, describePortConflict, installLifecycle } from './nd-mem-bridge-lifecycle.mjs';
 
 // Resolved from this file's own location, not process.cwd() — the bridge must
 // find its assets the same way regardless of the directory it's launched from.
@@ -85,7 +86,7 @@ function pollForChanges() {
   // sequential loop that easily lands two writes in one millisecond.
   broadcast('memory-change', { path: MEMORY_PATH, fingerprint, changedAt: new Date().toISOString() });
 }
-setInterval(pollForChanges, POLL_MS);
+const pollTimer = setInterval(pollForChanges, POLL_MS);
 
 app.get('/health', (_req, res) => res.json({ ok: true, port: PORT, memoryPath: MEMORY_PATH, pollMs: POLL_MS }));
 app.get('/memories', (_req, res) => { try { res.json(readSnapshot()); } catch (error) { res.status(500).json({ error: String(error), path: MEMORY_PATH }); } });
@@ -367,7 +368,48 @@ function maybeOpenBridgeUI() {
   });
 }
 
-app.listen(PORT, () => {
+// server.address(), NOT the callback, is the proof that we own the port.
+//
+// On Windows the listen callback fires even when the bind LOSES: node binds
+// dual-stack, the IPv6 bind fails, and EADDRINUSE arrives a tick after the
+// callback has already run. Measured against a real held 3737 on 2026-08-03 —
+// address() is null in the callback, yet the banner printed {"ok":true} and
+// maybeOpenBridgeUI() opened a browser onto the OLD bridge, quietly confirming
+// the wrong conclusion. Anything that announces success has to ask the socket.
+const server = app.listen(PORT, () => {
+  if (server.address() === null) return; // the 'error' handler below has this
   console.log(JSON.stringify({ ok: true, port: PORT, memoryPath: MEMORY_PATH, pollMs: POLL_MS }));
   maybeOpenBridgeUI();
 });
+
+// Without this, a bridge that loses the bind race stays alive forever, doing
+// nothing, looking healthy to `ps`. That is how a five-day-old bridge kept
+// serving a route set the user's page had already moved past, and why
+// restarting appeared not to help. Exit, and say who has the port.
+server.on('error', async (error) => {
+  // Nothing is listening, so the only thing keeping this process alive is the
+  // poll timer. Clearing it lets the process end on its own once stderr has
+  // drained, rather than process.exit() cutting the message off mid-write —
+  // on Windows a pipe write from console.error is asynchronous, and truncating
+  // the one message this whole issue exists to print would be a poor joke.
+  clearInterval(pollTimer);
+  process.exitCode = 1;
+
+  if (error.code !== 'EADDRINUSE') {
+    console.error('Bridge: FATAL — listen failed:', error);
+    return;
+  }
+  try {
+    const owners = await findPortOwners(PORT);
+    console.error(describePortConflict(PORT, owners));
+  } catch (lookupError) {
+    // The report must survive a failure inside the reporting. Ownership is a
+    // nicety; "this port is taken and I am not running" is the message.
+    console.error(describePortConflict(PORT, []));
+    console.error('Bridge: (port owner lookup failed:', lookupError.message, ')');
+  }
+});
+
+// The daemon is deliberately NOT stopped here — it is shared, and outliving the
+// bridge is its job. See the note in nd-mem-bridge-lifecycle.mjs.
+installLifecycle({ server, timers: [pollTimer], clients });

--- a/scripts/nd-mem-bridge-server.mjs
+++ b/scripts/nd-mem-bridge-server.mjs
@@ -9,7 +9,7 @@ import * as readline from 'readline';
 import { ensureDaemon } from '../build/core/ensure-daemon.js';
 import { resolveDaemonPort } from '../build/core/run-mode.js';
 import { parseSearchResults } from './nd-mem-rolodex-helpers.mjs';
-import { findPortOwners, describePortConflict, installLifecycle } from './nd-mem-bridge-lifecycle.mjs';
+import { findPortOwners, describePortConflict, installLifecycle, resolvePort } from './nd-mem-bridge-lifecycle.mjs';
 
 // Resolved from this file's own location, not process.cwd() — the bridge must
 // find its assets the same way regardless of the directory it's launched from.
@@ -17,7 +17,16 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(SCRIPT_DIR, '..');
 
 const app = express();
-const PORT = Number(process.env.ND_MEM_BRIDGE_PORT || 3737);
+// Validated here rather than left to app.listen(), which throws
+// ERR_SOCKET_BAD_PORT complaining about "options.port" — not a thing anyone
+// set. Name the setting the user actually got wrong.
+let PORT;
+try {
+  PORT = resolvePort(process.env.ND_MEM_BRIDGE_PORT, 3737);
+} catch (error) {
+  console.error(`Bridge: FATAL — ${error.message}`);
+  process.exit(1);
+}
 const USER_HOME = os.homedir();
 const DEFAULT_MEMORY_PATH = path.join(USER_HOME, '.neurodivergent-memory', 'memories.json');
 const MEMORY_PATH = process.env.ND_MEM_FILE || DEFAULT_MEMORY_PATH;

--- a/scripts/nd-mem-bridge-server.mjs
+++ b/scripts/nd-mem-bridge-server.mjs
@@ -394,6 +394,12 @@ server.on('error', async (error) => {
   // the one message this whole issue exists to print would be a poor joke.
   clearInterval(pollTimer);
   process.exitCode = 1;
+  // Unconditional, not incidental: on the measured EADDRINUSE path address() is
+  // already null and there is no handle to release, but this handler fires for
+  // ANY listen error, and one that arrived with the handle still live would
+  // otherwise leave a process that reported failure and then ran forever. The
+  // callback keeps ERR_SERVER_NOT_RUNNING from surfacing as an 'error' event.
+  server.close(() => {});
 
   if (error.code !== 'EADDRINUSE') {
     console.error('Bridge: FATAL — listen failed:', error);

--- a/scripts/nd-mem-bridge-stop.mjs
+++ b/scripts/nd-mem-bridge-stop.mjs
@@ -10,10 +10,13 @@
  * Before killing, this confirms the listener answers /health the way the bridge
  * does, so running it with a stale ND_MEM_BRIDGE_PORT cannot shoot an unrelated
  * dev server that happens to be on that port. --force skips the probe.
+ *
+ * Exits via process.exitCode rather than process.exit(): on Windows a write to
+ * a pipe is asynchronous, and process.exit() can cut off the very line that
+ * explains what happened. Letting the script end on its own flushes it.
  */
-import { findPortOwners, portOwnerCommand } from './nd-mem-bridge-lifecycle.mjs';
+import { findPortOwners, portOwnerCommand, resolvePort } from './nd-mem-bridge-lifecycle.mjs';
 
-const PORT = Number(process.env.ND_MEM_BRIDGE_PORT || 3737);
 const FORCE = process.argv.slice(2).includes('--force');
 
 async function looksLikeBridge(port) {
@@ -36,38 +39,50 @@ async function looksLikeBridge(port) {
   }
 }
 
-const owners = await findPortOwners(PORT);
-
-if (owners.length === 0) {
-  // Nothing to stop is success, or `npm run bridge:stop && npm run bridge`
-  // would fail on the first clean run.
-  console.log(`No process is listening on port ${PORT} — nothing to stop.`);
-  process.exit(0);
-}
-
-if (!FORCE && !(await looksLikeBridge(PORT))) {
-  console.error(
-    `Refusing to stop pid(s) ${owners.join(', ')}: whatever holds port ${PORT} does not answer /health `
-    + 'like the bridge does. Check it before killing it:\n'
-    + `  ${portOwnerCommand(PORT)}\n`
-    + 'Re-run with --force if you are sure.',
-  );
-  process.exit(1);
-}
-
-let failed = 0;
-for (const pid of owners) {
+async function main() {
+  let port;
   try {
-    // On POSIX this reaches the SIGTERM handler installed by
-    // nd-mem-bridge-lifecycle and the bridge closes cleanly. On Windows there
-    // is no deliverable signal — this is a TerminateProcess and the handler
-    // does not run. That is the platform's floor, not a choice.
-    process.kill(pid, 'SIGTERM');
-    console.log(`Stopped the process holding port ${PORT}: pid ${pid}.`);
+    port = resolvePort(process.env.ND_MEM_BRIDGE_PORT, 3737);
   } catch (error) {
-    failed += 1;
-    console.error(`Could not stop pid ${pid} on port ${PORT}: ${error.message}`);
+    console.error(`Cannot stop the bridge: ${error.message}`);
+    return 1;
   }
+
+  const owners = await findPortOwners(port);
+
+  if (owners.length === 0) {
+    // Nothing to stop is success, or `npm run bridge:stop && npm run bridge`
+    // would fail on the first clean run.
+    console.log(`No process is listening on port ${port} — nothing to stop.`);
+    return 0;
+  }
+
+  if (!FORCE && !(await looksLikeBridge(port))) {
+    console.error(
+      `Refusing to stop pid(s) ${owners.join(', ')}: whatever holds port ${port} does not answer /health `
+      + 'like the bridge does. Check it before killing it:\n'
+      + `  ${portOwnerCommand(port)}\n`
+      + 'Re-run with --force if you are sure.',
+    );
+    return 1;
+  }
+
+  let failed = 0;
+  for (const pid of owners) {
+    try {
+      // On POSIX this reaches the SIGTERM handler installed by
+      // nd-mem-bridge-lifecycle and the bridge closes cleanly. On Windows there
+      // is no deliverable signal — this is a TerminateProcess and the handler
+      // does not run. That is the platform's floor, not a choice.
+      process.kill(pid, 'SIGTERM');
+      console.log(`Stopped the process holding port ${port}: pid ${pid}.`);
+    } catch (error) {
+      failed += 1;
+      console.error(`Could not stop pid ${pid} on port ${port}: ${error.message}`);
+    }
+  }
+
+  return failed > 0 ? 1 : 0;
 }
 
-process.exit(failed > 0 ? 1 : 0);
+process.exitCode = await main();

--- a/scripts/nd-mem-bridge-stop.mjs
+++ b/scripts/nd-mem-bridge-stop.mjs
@@ -23,9 +23,14 @@ async function looksLikeBridge(port) {
     });
     if (!res.ok) return false;
     const body = await res.json();
-    // An older bridge is exactly what this script most needs to stop, so the
-    // probe checks only the fields /health has always had.
-    return body?.ok === true && typeof body?.memoryPath === 'string';
+    // The DAEMON also answers {ok:true, ..., memoryPath} — plus mode:"daemon" —
+    // and it is the one process the architecture says must outlive the bridge.
+    // Its port and the bridge's are both env-driven neighbours, so a stale
+    // ND_MEM_BRIDGE_PORT aimed at the daemon is an ordinary mistake. Refuse
+    // anything that calls itself the daemon, and require pollMs, which is the
+    // bridge's own /health field and nothing else's.
+    if (body?.mode === 'daemon') return false;
+    return body?.ok === true && typeof body?.memoryPath === 'string' && typeof body?.pollMs === 'number';
   } catch {
     return false;
   }

--- a/scripts/nd-mem-bridge-stop.mjs
+++ b/scripts/nd-mem-bridge-stop.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Stop the bridge by PORT OWNERSHIP, never by a remembered pid.
+ *
+ * The pid you remember is not necessarily the pid that holds the port. In the
+ * 2026-08-02 incident five bridge processes existed and only the oldest was
+ * listening; the user killed the one attached to their terminal and nothing
+ * changed. The port knows who owns it — ask the port.
+ *
+ * Before killing, this confirms the listener answers /health the way the bridge
+ * does, so running it with a stale ND_MEM_BRIDGE_PORT cannot shoot an unrelated
+ * dev server that happens to be on that port. --force skips the probe.
+ */
+import { findPortOwners, portOwnerCommand } from './nd-mem-bridge-lifecycle.mjs';
+
+const PORT = Number(process.env.ND_MEM_BRIDGE_PORT || 3737);
+const FORCE = process.argv.slice(2).includes('--force');
+
+async function looksLikeBridge(port) {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) return false;
+    const body = await res.json();
+    // An older bridge is exactly what this script most needs to stop, so the
+    // probe checks only the fields /health has always had.
+    return body?.ok === true && typeof body?.memoryPath === 'string';
+  } catch {
+    return false;
+  }
+}
+
+const owners = await findPortOwners(PORT);
+
+if (owners.length === 0) {
+  // Nothing to stop is success, or `npm run bridge:stop && npm run bridge`
+  // would fail on the first clean run.
+  console.log(`No process is listening on port ${PORT} — nothing to stop.`);
+  process.exit(0);
+}
+
+if (!FORCE && !(await looksLikeBridge(PORT))) {
+  console.error(
+    `Refusing to stop pid(s) ${owners.join(', ')}: whatever holds port ${PORT} does not answer /health `
+    + 'like the bridge does. Check it before killing it:\n'
+    + `  ${portOwnerCommand(PORT)}\n`
+    + 'Re-run with --force if you are sure.',
+  );
+  process.exit(1);
+}
+
+let failed = 0;
+for (const pid of owners) {
+  try {
+    // On POSIX this reaches the SIGTERM handler installed by
+    // nd-mem-bridge-lifecycle and the bridge closes cleanly. On Windows there
+    // is no deliverable signal — this is a TerminateProcess and the handler
+    // does not run. That is the platform's floor, not a choice.
+    process.kill(pid, 'SIGTERM');
+    console.log(`Stopped the process holding port ${PORT}: pid ${pid}.`);
+  } catch (error) {
+    failed += 1;
+    console.error(`Could not stop pid ${pid} on port ${PORT}: ${error.message}`);
+  }
+}
+
+process.exit(failed > 0 ? 1 : 0);

--- a/test/bridge-lifecycle.test.mjs
+++ b/test/bridge-lifecycle.test.mjs
@@ -1,0 +1,312 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
+
+import {
+  findPortOwners,
+  describePortConflict,
+  installLifecycle,
+} from "../scripts/nd-mem-bridge-lifecycle.mjs";
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+function listenOn(port) {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(port, () => resolve(srv));
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// --- describePortConflict -------------------------------------------------
+// The message IS the fix for #171: the user saw a silent non-listening process
+// and went looking at their network. Everything they needed has to be in here.
+
+test("describePortConflict names the port and every holding pid", () => {
+  const message = describePortConflict(3737, [47640]);
+  assert.match(message, /3737/);
+  assert.match(message, /47640/);
+});
+
+test("describePortConflict lists multiple owners", () => {
+  const message = describePortConflict(3737, [111, 222]);
+  assert.match(message, /111/);
+  assert.match(message, /222/);
+});
+
+test("describePortConflict still names the port when ownership cannot be resolved", () => {
+  const message = describePortConflict(3737, []);
+  assert.match(message, /3737/);
+  // No pid is worse than a pid, but it must not read as "no conflict".
+  assert.match(message, /in use|already/i);
+});
+
+test("describePortConflict tells the reader how to find the owner themselves", () => {
+  // The pid lookup is best-effort; when it comes back empty the message has to
+  // hand over the command that answers the question, or the user is back to
+  // guessing — which is the whole failure this issue exists to stop.
+  const message = describePortConflict(3737, []);
+  assert.match(message, /Get-NetTCPConnection|lsof/);
+});
+
+// --- findPortOwners -------------------------------------------------------
+
+test("findPortOwners finds this process holding a port it is listening on", async () => {
+  const port = await getFreePort();
+  const server = await listenOn(port);
+  try {
+    const owners = await findPortOwners(port);
+    assert.ok(
+      owners.includes(process.pid),
+      `expected ${process.pid} among owners of ${port}, got ${JSON.stringify(owners)}`,
+    );
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});
+
+test("findPortOwners returns nothing for a port nobody holds", async () => {
+  const port = await getFreePort();
+  assert.deepEqual(await findPortOwners(port), []);
+});
+
+test("findPortOwners resolves to an empty list rather than throwing when the lookup fails", async () => {
+  // Best-effort by contract: a machine without lsof, or a locked-down
+  // PowerShell, must degrade to "port is in use, owner unknown" — never to a
+  // crash inside the error path of another crash.
+  const owners = await findPortOwners(3737, {
+    execFileImpl: (_cmd, _args, _opts, cb) => cb(new Error("ENOENT")),
+  });
+  assert.deepEqual(owners, []);
+});
+
+// --- installLifecycle -----------------------------------------------------
+
+function fakeShutdownRig() {
+  const closed = [];
+  const exits = [];
+  const server = { close(cb) { closed.push(true); cb?.(); } };
+  const emitter = new EventEmitter();
+  return { closed, exits, server, emitter };
+}
+
+test("shutdown stops the timers it was given", async () => {
+  const { server, emitter, exits } = fakeShutdownRig();
+  let ticks = 0;
+  const timer = setInterval(() => { ticks += 1; }, 5);
+
+  const { shutdown } = installLifecycle({
+    server, emitter, timers: [timer], clients: new Set(),
+    onExit: (code) => exits.push(code), log: () => {},
+  });
+
+  await sleep(30);
+  assert.ok(ticks > 0, "timer should have been running before shutdown");
+  shutdown("SIGINT");
+  const atShutdown = ticks;
+  await sleep(30);
+  assert.equal(ticks, atShutdown, "timer kept firing after shutdown");
+});
+
+test("shutdown ends open SSE responses, which would otherwise hold the server open", () => {
+  const { server, emitter, exits } = fakeShutdownRig();
+  const ended = [];
+  const clients = new Set([
+    { end: () => ended.push("a") },
+    { end: () => ended.push("b") },
+  ]);
+
+  const { shutdown } = installLifecycle({
+    server, emitter, timers: [], clients,
+    onExit: (code) => exits.push(code), log: () => {},
+  });
+  shutdown("SIGTERM");
+
+  assert.deepEqual(ended.sort(), ["a", "b"]);
+  assert.equal(clients.size, 0, "client set should be emptied");
+});
+
+test("shutdown survives a response that throws on end", () => {
+  const { server, emitter, exits } = fakeShutdownRig();
+  const ended = [];
+  const clients = new Set([
+    { end: () => { throw new Error("socket already gone"); } },
+    { end: () => ended.push("b") },
+  ]);
+
+  const { shutdown } = installLifecycle({
+    server, emitter, timers: [], clients,
+    onExit: (code) => exits.push(code), log: () => {},
+  });
+  shutdown("SIGTERM");
+
+  // One dead socket must not strand the rest of the teardown.
+  assert.deepEqual(ended, ["b"]);
+  assert.deepEqual(exits, [0]);
+});
+
+test("shutdown closes the server and exits 0", () => {
+  const { server, emitter, exits, closed } = fakeShutdownRig();
+  const { shutdown } = installLifecycle({
+    server, emitter, timers: [], clients: new Set(),
+    onExit: (code) => exits.push(code), log: () => {},
+  });
+  shutdown("SIGINT");
+  assert.deepEqual(closed, [true]);
+  assert.deepEqual(exits, [0]);
+});
+
+test("a second signal does not run the teardown twice", () => {
+  const { server, emitter, exits, closed } = fakeShutdownRig();
+  installLifecycle({
+    server, emitter, timers: [], clients: new Set(),
+    onExit: (code) => exits.push(code), log: () => {},
+  });
+  emitter.emit("SIGINT");
+  emitter.emit("SIGINT");
+  emitter.emit("SIGTERM");
+  assert.deepEqual(closed, [true], "server.close ran more than once");
+  assert.deepEqual(exits, [0], "exited more than once");
+});
+
+test("installLifecycle listens for both SIGINT and SIGTERM", () => {
+  const { server, emitter, exits } = fakeShutdownRig();
+  installLifecycle({
+    server, emitter, timers: [], clients: new Set(),
+    onExit: (code) => exits.push(code), log: () => {},
+  });
+  assert.equal(emitter.listenerCount("SIGINT"), 1);
+  assert.equal(emitter.listenerCount("SIGTERM"), 1);
+});
+
+test("a server that hangs on close still exits, on a deadline", async () => {
+  // server.close() waits for every keep-alive connection to drain. A phone
+  // holding an SSE stream that we failed to end would keep the bridge alive
+  // forever, which is the exact "running but useless" state #171 is about.
+  const emitter = new EventEmitter();
+  const exits = [];
+  const server = { close() { /* never calls back */ } };
+
+  installLifecycle({
+    server, emitter, timers: [], clients: new Set(),
+    onExit: (code) => exits.push(code), log: () => {}, forceExitMs: 20,
+  });
+  emitter.emit("SIGINT");
+  assert.deepEqual(exits, [], "should not have exited synchronously");
+  await sleep(60);
+  assert.deepEqual(exits, [1], "should have force-exited after the deadline");
+});
+
+// --- the bridge itself ----------------------------------------------------
+
+function runNode(args, env = {}) {
+  const child = spawn(process.execPath, args, {
+    cwd: process.cwd(),
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (c) => { stdout += c.toString(); });
+  child.stderr.on("data", (c) => { stderr += c.toString(); });
+  const done = new Promise((resolve) => {
+    child.on("exit", (code) => resolve({ code, stdout, stderr }));
+  });
+  return { child, done, out: () => ({ stdout, stderr }) };
+}
+
+test("the bridge exits loudly instead of lingering when its port is held", async () => {
+  const port = await getFreePort();
+  const squatter = await listenOn(port);
+  try {
+    const { child, done } = runNode(["scripts/nd-mem-bridge-server.mjs", "--no-open"], {
+      ND_MEM_BRIDGE_PORT: String(port),
+    });
+    const timeout = setTimeout(() => child.kill(), 20000);
+    const { code, stdout, stderr } = await done;
+    clearTimeout(timeout);
+
+    const output = `${stdout}\n${stderr}`;
+    // "Running but not listening" is the state that made the user distrust
+    // their network instead of their process list. It must not be reachable.
+    assert.equal(code, 1, `expected exit 1, got ${code}. output:\n${output}`);
+    assert.match(output, new RegExp(String(port)), `port not named:\n${output}`);
+
+    // On Windows the listen CALLBACK fires even when the bind loses: the
+    // dual-stack IPv6 bind fails a tick later, and server.address() is null the
+    // whole time. Measured 2026-08-03 against a real bridge on 3737 — the
+    // startup banner printed ok:true and maybeOpenBridgeUI() ran, which would
+    // open a browser onto the OLD bridge and confirm the wrong conclusion.
+    assert.doesNotMatch(stdout, /"ok":\s*true/, `announced success on a failed bind:\n${output}`);
+
+    // The contract is "say who holds it, or say how to find out" — the pid
+    // lookup shells out and a machine without lsof/netstat cannot answer.
+    // Asserting the pid unconditionally would fail on tooling, not behaviour;
+    // findPortOwners has its own test for whether the lookup itself works.
+    const resolvable = (await findPortOwners(port)).includes(process.pid);
+    if (resolvable) {
+      assert.match(output, new RegExp(String(process.pid)), `holding pid not named:\n${output}`);
+    } else {
+      assert.match(output, /Get-NetTCPConnection|lsof/, `no way to find the owner offered:\n${output}`);
+    }
+  } finally {
+    await new Promise((r) => squatter.close(r));
+  }
+});
+
+test("bridge:stop kills whoever holds the port, without being told a pid", async () => {
+  const port = await getFreePort();
+  // A stand-in bridge: it answers /health the way the real one does, which is
+  // what the stop script uses to confirm it is not shooting an unrelated
+  // process that happens to be on this port.
+  const source = `
+    const http = require('http');
+    http.createServer((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ ok: true, port: ${port}, memoryPath: 'x', pollMs: 1500 }));
+    }).listen(${port}, '127.0.0.1');
+  `;
+  const { child, done } = runNode(["-e", source]);
+
+  try {
+    const deadline = Date.now() + 8000;
+    let up = false;
+    while (Date.now() < deadline && !up) {
+      try { up = (await fetch(`http://127.0.0.1:${port}/health`)).ok; } catch { await sleep(100); }
+    }
+    assert.ok(up, "stand-in bridge never came up");
+
+    const stop = runNode(["scripts/nd-mem-bridge-stop.mjs"], { ND_MEM_BRIDGE_PORT: String(port) });
+    const stopped = await stop.done;
+    assert.equal(stopped.code, 0, `stop failed:\n${stopped.stdout}\n${stopped.stderr}`);
+    assert.match(`${stopped.stdout}${stopped.stderr}`, new RegExp(String(child.pid)));
+
+    const exit = await Promise.race([done, sleep(5000).then(() => "timeout")]);
+    assert.notEqual(exit, "timeout", "port holder was still alive after bridge:stop");
+  } finally {
+    child.kill();
+  }
+});
+
+test("bridge:stop reports plainly when nothing holds the port", async () => {
+  const port = await getFreePort();
+  const { done } = runNode(["scripts/nd-mem-bridge-stop.mjs"], { ND_MEM_BRIDGE_PORT: String(port) });
+  const { code, stdout, stderr } = await done;
+  // Nothing to stop is a success, not a failure — otherwise `bridge:stop &&
+  // bridge` breaks on the first clean run.
+  assert.equal(code, 0, `${stdout}\n${stderr}`);
+  assert.match(`${stdout}${stderr}`, /no .*(process|listener)|nothing/i);
+});

--- a/test/bridge-lifecycle.test.mjs
+++ b/test/bridge-lifecycle.test.mjs
@@ -8,6 +8,7 @@ import {
   findPortOwners,
   describePortConflict,
   installLifecycle,
+  parseNetstat,
 } from "../scripts/nd-mem-bridge-lifecycle.mjs";
 
 function getFreePort() {
@@ -72,6 +73,72 @@ test("findPortOwners finds this process holding a port it is listening on", asyn
     assert.ok(
       owners.includes(process.pid),
       `expected ${process.pid} among owners of ${port}, got ${JSON.stringify(owners)}`,
+    );
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});
+
+// The Windows parser only ever runs on Windows, and CI is ubuntu — so without
+// fixture tests it is verified by nobody. These rows are real `netstat -ano`
+// output, captured on 2026-08-03.
+test("parseNetstat finds an IPv6 listener", () => {
+  const rows = "  TCP    [::1]:13739            [::]:0                 LISTENING       33164";
+  assert.deepEqual(parseNetstat(rows, 13739), [33164]);
+});
+
+test("parseNetstat finds an IPv4 listener", () => {
+  const rows = "  TCP    0.0.0.0:3737           0.0.0.0:0              LISTENING       47640";
+  assert.deepEqual(parseNetstat(rows, 3737), [47640]);
+});
+
+test("parseNetstat ignores established connections on the same port", () => {
+  const rows = [
+    "  TCP    0.0.0.0:3737           0.0.0.0:0              LISTENING       47640",
+    "  TCP    127.0.0.1:3737         127.0.0.1:63724        ESTABLISHED     9001",
+    "  TCP    [::1]:3737             [::1]:63725            ESTABLISHED     9002",
+  ].join("\r\n");
+  // A client connected to the bridge is not the bridge. Killing 9001 would
+  // shoot the user's own browser.
+  assert.deepEqual(parseNetstat(rows, 3737), [47640]);
+});
+
+test("parseNetstat does not confuse a port with one that merely ends in it", () => {
+  const rows = [
+    "  TCP    0.0.0.0:13737          0.0.0.0:0              LISTENING       1111",
+    "  TCP    0.0.0.0:3737           0.0.0.0:0              LISTENING       2222",
+  ].join("\r\n");
+  assert.deepEqual(parseNetstat(rows, 3737), [2222]);
+});
+
+test("parseNetstat ignores UDP rows", () => {
+  const rows = "  UDP    0.0.0.0:3737           *:*                                    3333";
+  assert.deepEqual(parseNetstat(rows, 3737), []);
+});
+
+test("findPortOwners finds an IPv6-only listener", async (t) => {
+  // Node resolves `localhost` to ::1 first, so an IPv6-only listener is not
+  // exotic. `netstat -p TCP` shows the IPv4 table ONLY — an IPv6 listener is
+  // invisible to it, which made findPortOwners report an empty list and
+  // bridge:stop announce "nothing to stop" while a bridge held the port. That
+  // is the same false reassurance this whole issue is about.
+  const port = await getFreePort();
+  let server;
+  try {
+    server = await new Promise((resolve, reject) => {
+      const srv = net.createServer();
+      srv.once("error", reject);
+      srv.listen(port, "::1", () => resolve(srv));
+    });
+  } catch {
+    t.skip("no IPv6 loopback on this machine");
+    return;
+  }
+  try {
+    const owners = await findPortOwners(port);
+    assert.ok(
+      owners.includes(process.pid),
+      `IPv6 listener not found: expected ${process.pid}, got ${JSON.stringify(owners)}`,
     );
   } finally {
     await new Promise((r) => server.close(r));
@@ -296,6 +363,44 @@ test("bridge:stop kills whoever holds the port, without being told a pid", async
 
     const exit = await Promise.race([done, sleep(5000).then(() => "timeout")]);
     assert.notEqual(exit, "timeout", "port holder was still alive after bridge:stop");
+  } finally {
+    child.kill();
+  }
+});
+
+test("bridge:stop refuses to kill the shared daemon", async () => {
+  // The daemon's /health is {ok:true, pid, version, memoryPath, mode:"daemon",
+  // memoryCount} — it satisfies a naive "ok and memoryPath" probe exactly. The
+  // daemon and bridge ports are neighbours by convention and both env-driven,
+  // so a stale ND_MEM_BRIDGE_PORT pointing at the daemon is an ordinary
+  // mistake, and the daemon is the ONE process the architecture says must
+  // outlive the bridge.
+  const port = await getFreePort();
+  const source = `
+    const http = require('http');
+    http.createServer((req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ ok: true, pid: process.pid, version: '0.3.9',
+        memoryPath: 'x', mode: 'daemon', memoryCount: 5 }));
+    }).listen(${port}, '127.0.0.1');
+  `;
+  const { child, done } = runNode(["-e", source]);
+
+  try {
+    const deadline = Date.now() + 8000;
+    let up = false;
+    while (Date.now() < deadline && !up) {
+      try { up = (await fetch(`http://127.0.0.1:${port}/health`)).ok; } catch { await sleep(100); }
+    }
+    assert.ok(up, "stand-in daemon never came up");
+
+    const stopped = await runNode(["scripts/nd-mem-bridge-stop.mjs"], {
+      ND_MEM_BRIDGE_PORT: String(port),
+    }).done;
+    assert.notEqual(stopped.code, 0, "should have refused");
+
+    const alive = await Promise.race([done, sleep(1500).then(() => "alive")]);
+    assert.equal(alive, "alive", "bridge:stop killed the shared daemon");
   } finally {
     child.kill();
   }

--- a/test/bridge-lifecycle.test.mjs
+++ b/test/bridge-lifecycle.test.mjs
@@ -406,6 +406,41 @@ test("bridge:stop refuses to kill the shared daemon", async () => {
   }
 });
 
+// A misconfigured port must not read as a clean machine. Number('abc') is NaN,
+// nothing can ever be listening on NaN, so the ownership lookup comes back
+// empty and the script would announce "nothing to stop" and exit 0 — reporting
+// success for a run that never checked anything. Same class as every other bug
+// in this issue: an absence taken as evidence when the instrument was blind.
+for (const [label, value] of [
+  ["non-numeric", "abc"],
+  ["out of range", "70000"],
+  ["zero", "0"],
+  ["fractional", "3737.5"],
+]) {
+  test(`bridge:stop rejects a ${label} port instead of reporting success`, async () => {
+    const { code, stdout, stderr } = await runNode(["scripts/nd-mem-bridge-stop.mjs"], {
+      ND_MEM_BRIDGE_PORT: value,
+    }).done;
+    const output = `${stdout}${stderr}`;
+    assert.notEqual(code, 0, `should have failed. output:\n${output}`);
+    assert.doesNotMatch(output, /nothing to stop/i, `claimed nothing to stop:\n${output}`);
+    assert.match(output, /ND_MEM_BRIDGE_PORT/, `did not name the setting at fault:\n${output}`);
+    assert.match(output, new RegExp(value.replace(".", "\\.")), `did not echo the bad value:\n${output}`);
+  });
+}
+
+test("the bridge names the setting at fault when its port is unusable", async () => {
+  // Left alone this is a raw ERR_SOCKET_BAD_PORT stack trace naming
+  // "options.port", which is not a thing the user set.
+  const { code, stdout, stderr } = await runNode(
+    ["scripts/nd-mem-bridge-server.mjs", "--no-open"],
+    { ND_MEM_BRIDGE_PORT: "abc" },
+  ).done;
+  const output = `${stdout}${stderr}`;
+  assert.notEqual(code, 0, `should have failed:\n${output}`);
+  assert.match(output, /ND_MEM_BRIDGE_PORT/, `did not name the setting at fault:\n${output}`);
+});
+
 test("bridge:stop reports plainly when nothing holds the port", async () => {
   const port = await getFreePort();
   const { done } = runNode(["scripts/nd-mem-bridge-stop.mjs"], { ND_MEM_BRIDGE_PORT: String(port) });


### PR DESCRIPTION
Closes #171.

## The problem

A bridge that lost the bind race printed nothing and kept running. `scripts/nd-mem-bridge-server.mjs` registered no `listen` error handler and no `SIGINT`/`SIGTERM` handlers, and closing a terminal on Windows orphans the child rather than killing it — so they accumulated. On 2026-08-02 a five-day-old bridge still owned port 3737 and answered `/health` with `200` from code that predated the `/search` route: the page's search 404'd, every check said "running", and restarting appeared not to help. A process that is running but not listening is worse than one that died.

## What this changes

1. **`EADDRINUSE` exits 1 and names the holding pid.** Best-effort and cross-platform — `netstat -ano` on Windows (matched by socket *shape*, not the localised `LISTENING` word), `lsof` then `ss` elsewhere. When the lookup can't answer, the message degrades to the command that answers it, never to a crash inside the error path of another failure.
2. **`SIGINT`/`SIGTERM` tear down cleanly** — close the server, clear the poll timer, and end open SSE responses, which otherwise hold the server open indefinitely; a deadline force-exits if `close` still hangs. **The shared daemon is deliberately left running.** The single-writer migration deleted the old signal block with the note "there is no child to kill — the daemon deliberately outlives the bridge"; that was right about the child and wrong about the socket, the timer, and the streams. There's a comment at the handler saying so, so it doesn't get deleted a second time for the same correct-but-narrow reason.
3. **`npm run bridge` / `npm run bridge:stop`**, stopping by **port ownership** rather than a remembered pid — the pid you wrote down is not necessarily the one holding the port. `bridge:stop` refuses to kill something that doesn't answer `/health` like the bridge does (`--force` overrides), and treats "nothing running" as success so `bridge:stop && bridge` works on a clean machine.

## Three bugs found during the work, not from the issue text

**The bridge announced success on a failed start.** On Windows the `listen` callback fires even when the bind loses — Node binds dual-stack and `EADDRINUSE` arrives a tick after the callback has already run (measured: callback 1.77ms, error 2.35ms). So the bridge printed its `{"ok":true,...}` startup banner on a failed start, and `--open` launched a browser at `localhost:3737` — i.e. **at the old bridge that already held the port**, producing a working-looking page as confirmation of the wrong conclusion. `server.address()` is `null` in that callback, and success is now gated on it. Found by running the real bridge against a real held port; every test written from the issue text passed with this bug in place.

**`netstat -ano -p TCP` is blind to IPv6 listeners.** `-p TCP` selects the IPv4 table only, so `findPortOwners` returned `[]` while a bridge held the port and `bridge:stop` announced *"nothing to stop"* and exited 0 — the same false reassurance this issue exists to kill, reproduced inside the new tooling. Node resolves `localhost` to `::1` first, so IPv6-only listeners are ordinary. Plain `netstat -ano` lists every table; the existing row-shape filter already rejects the rest. Found by an independent review pass and reproduced before fixing.

**`bridge:stop` could have killed the shared daemon.** The daemon's `/health` is `{ok:true, pid, version, memoryPath, mode:"daemon", memoryCount}` — it satisfied the "ok and memoryPath" probe exactly. Both ports are env-driven neighbours, so a stale `ND_MEM_BRIDGE_PORT` aimed at the daemon would have had `bridge:stop` confirm "that's the bridge" and SIGTERM the one process the architecture says must outlive it. Now rejects `mode:"daemon"` and requires `pollMs`, which only the bridge's `/health` carries.

Also fixed from the same review: the listen-error path now calls `server.close()`, so exiting is unconditional rather than depending on `address()` having been `null`; and the `ss` fallback reads every pid on a row, not just the first (SO_REUSEPORT siblings).

## Testing

`test/bridge-lifecycle.test.mjs` — 24 tests, all passing.

- `describePortConflict`: names the port and every holding pid; when ownership is unresolvable, still reads as a conflict and hands over the lookup command.
- `parseNetstat` (exported for this): fixture rows pinning an IPv6 listener, an IPv4 listener, `ESTABLISHED` rows on the same port (a connected browser is not the bridge), `:13737` when asking for `:3737`, and UDP rows. **The Windows parser never runs on ubuntu CI, so without these it was verified by nobody** — and their absence is exactly why the IPv6 bug shipped into the branch.
- `findPortOwners`: finds this process on a dual-stack port and on an IPv6-only port; empty for a free port; resolves to `[]` rather than throwing when the lookup command fails.
- `installLifecycle`: stops the timers it was given (asserted behaviourally — a real interval stops ticking); ends open SSE responses and empties the client set; survives a response that throws on `end`; closes the server and exits 0; a second signal does not re-run the teardown; force-exits on a deadline when `close` hangs.
- The bridge itself: exits 1 on a held port, names the port, names the pid *when the platform can resolve it* and otherwise offers the command, and does not print `"ok":true`.
- `bridge:stop`: kills the port holder without being told a pid; **refuses to kill the shared daemon**; reports plainly when nothing holds the port.

Each guard was verified by **mutating the implementation** and confirming the matching test fails: removing the `error` handler (bridge lingers, exit code `null`), removing the re-entrancy guard, removing the force-exit deadline, and the `"ok":true` assertion. Both review defects were reproduced as failing tests before being fixed.

Verified live on this machine: against the bridge genuinely holding port 3737 (names pid 34084, exits 1, no false banner), and a full `npm run bridge` → `/health` → `npm run bridge:stop` cycle on a free port.

**Full suite: 351/353.** The 2 failures are the pre-existing template-wording drift in `test/agent-customization-wording.test.mjs`, unrelated to and untouched by this branch. `npm run lint` (tsc + markdownlint) clean.

## Known gaps

- `bridge:stop` stops the process that *holds* the port. Bridges that failed to bind and lingered are not listening, so an ownership lookup can't find them — this prevents new ones rather than reaping existing ones. A machine that already has a pile of them still needs a manual sweep by process name.
- There is a pid-reuse window between the ownership lookup and `process.kill`, and on a `SO_REUSEPORT` setup the `/health` probe vouches for one process while the loop kills all of them. Both judged narrow enough to accept for a dev tool.
