### PR TITLE
feat(mcp): agent_clock_in / agent_clock_out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Running locally on the development branch; not part of a release cut (version st
 
 ### Added
 
+- **`agent_clock_in` / `agent_clock_out`.** Identity has been bound automatically from the
+  MCP handshake's `clientInfo.name` since the per-connection sessions work, which covers the
+  common case but cannot serve two: several agents behind a single MCP client all report the
+  same `clientInfo.name` and are indistinguishable, and handing a session to a different role
+  mid-run previously meant reconnecting. `agent_clock_in` declares the identity explicitly and
+  `agent_clock_out` drops it; both sit on the same per-session `WeakMap` the auto-binding uses,
+  so one session can never affect another. The handshake now distinguishes a declared identity
+  (`clock_in`) from an inferred one (`client_info`). Clock-out is idempotent so it is safe in a
+  teardown path, and the existing auto-clock-out triggers — a `kind:handoff` write and
+  `close_task` — clear an explicitly clocked-in identity exactly as they clear an inferred one.
 - **Terminal keybinds for the bridge** (`S` stop, `R` restart, `O` open UI, `I` status,
   `?` help). `R` gives you a fresh process — the only way changed code is loaded — so
   `npm run bridge` now starts a small supervisor that owns the restart loop; a process

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Memories are organized by cognitive domain:
 - **`list_memories`** — Paginated listing with optional district/archetype/project_id/epistemic-status filters
 - **`memory_stats`** — Aggregate statistics (totals, per-district/per-project counts, most-accessed, orphans) with optional project scope
 - **`server_handshake`** — Return runtime server identity/version details for explicit client-side version confirmation
+- **`agent_clock_in`** — Declare the identity this session writes as; later calls that omit `agent_id` inherit it
+- **`agent_clock_out`** — Clear that identity, falling back to the unassigned default. Idempotent
 - **`storage_diagnostics`** — Show the resolved snapshot path, WAL path, and effective persistence source in one response
 - **`import_memories`** — Bulk-import from inline JSON entries or a snapshot `file_path`, with `dry_run`, dedupe policies, and explicit snapshot migration flags
 - **`prepare_memory_city_context`** — Tool mirror of `explore_memory_city` for clients that support tools but do not invoke MCP prompts

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -6675,10 +6675,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
           "Pass the identity this session should write as, e.g. agent_id: \"risk-reviewer\".",
         );
       }
-      if (session_id !== undefined && session_id !== null) validateSessionId(session_id);
+      // Normalize FIRST, reject what normalizes to empty, then validate the
+      // canonical form — the same three steps store_memory uses. Validating the
+      // raw string instead refused ids that normalize cleanly (" Task-42 "
+      // fails the pattern on its leading space), and skipping the empty check
+      // let null and whitespace fall silently through to the fallback, binding
+      // the identity to a session the caller never asked for.
+      let explicitSessionId: string | undefined;
+      if (session_id !== undefined) {
+        explicitSessionId = normalizeSessionId(session_id);
+        if (!explicitSessionId) {
+          throw createNMError(
+            NM_ERRORS.INPUT_VALIDATION_FAILED,
+            `Invalid session_id after normalization: ${session_id}`,
+            "session_id must normalize to a non-empty canonical value.",
+          );
+        }
+        validateSessionId(explicitSessionId);
+      }
 
       const previous = getActiveAgentSession(server);
-      const resolvedSessionId = normalizeSessionId(session_id)
+      const resolvedSessionId = explicitSessionId
         ?? previous?.session_id
         ?? extra.sessionId
         ?? "unknown";

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -4661,7 +4661,10 @@ export interface ActiveAgentSession {
   agent_id: string;
   session_id: string;
   bound_at: string;
-  source: "client_info" | "override";
+  // "clock_in" is deliberately distinct from "override": a caller reading the
+  // handshake needs to know whether an agent DECLARED this identity or the
+  // server merely inferred it from the client program's name.
+  source: "client_info" | "override" | "clock_in";
 }
 
 // Keyed by the per-session Server instance (Task 1 gives each MCP session its
@@ -5560,6 +5563,23 @@ function buildRegisteredToolDescriptors(): ToolDescriptor[] {
         }
       },
       {
+        name: "agent_clock_in",
+        description: "Declare the identity this session writes as. Every later call that omits agent_id is attributed to it, until agent_clock_out, a kind:handoff write, or close_task. Use when several agents share one MCP client (clientInfo.name cannot tell them apart), or to hand a session to a different role mid-run.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            agent_id: { type: "string", description: "Required. The identity to write as, e.g. \"risk-reviewer\"." },
+            session_id: { type: "string", description: "Optional. Scopes this identity's memories to a named session. Defaults to the session already bound, then to the transport's own session id." },
+          },
+          required: ["agent_id"],
+        }
+      },
+      {
+        name: "agent_clock_out",
+        description: "Clear this session's bound identity. Later calls that omit agent_id fall back to the unassigned default. Idempotent — safe to call when nothing is bound, so it can sit in a teardown path unconditionally.",
+        inputSchema: { type: "object", properties: {} }
+      },
+      {
         name: "import_memories",
         description: "Bulk-import memories from inline entries or from a snapshot file. Supports dry-run validation, dedupe policies, and explicit snapshot migration flags.",
         inputSchema: {
@@ -5884,6 +5904,9 @@ function toolWhenToUseHint(toolName: string): string {
     case "list_sessions":
     case "kanban_view":
       return "Use for broad inventory, pagination, or aggregate status checks across the graph.";
+    case "agent_clock_in":
+    case "agent_clock_out":
+      return "Use to declare or drop the identity this session writes as, when clientInfo.name cannot distinguish the agents behind one client.";
     case "update_status":
       return "Use to transition a memory's kanban status and optionally set current_slice or why_now.";
     case "publish_task":
@@ -6636,6 +6659,66 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
           ),
         );
       }
+    }
+
+    case "agent_clock_in": {
+      const { agent_id, session_id } = (request.params.arguments ?? {}) as any;
+      // normalizeOptionalAgentId rejects non-strings and blank strings, but
+      // returns undefined for a MISSING one — which is fine everywhere else
+      // (attribution falls back) and useless here, where declaring the identity
+      // is the entire operation.
+      const normalizedAgentId = normalizeOptionalAgentId(agent_id, "agent_id");
+      if (!normalizedAgentId) {
+        throw createNMError(
+          NM_ERRORS.INPUT_VALIDATION_FAILED,
+          "agent_clock_in requires an agent_id.",
+          "Pass the identity this session should write as, e.g. agent_id: \"risk-reviewer\".",
+        );
+      }
+      if (session_id !== undefined && session_id !== null) validateSessionId(session_id);
+
+      const previous = getActiveAgentSession(server);
+      const resolvedSessionId = normalizeSessionId(session_id)
+        ?? previous?.session_id
+        ?? extra.sessionId
+        ?? "unknown";
+      bindAgentSession(server, normalizedAgentId, resolvedSessionId, "clock_in");
+
+      const replaced = previous && previous.agent_id !== normalizedAgentId
+        ? `\nReplaced: ${previous.agent_id} (${previous.source})`
+        : "";
+      return {
+        content: [{
+          type: "text",
+          text: [
+            `🕐 Clocked in as ${normalizedAgentId}.`,
+            `session_id: ${resolvedSessionId}`,
+            "Calls that omit agent_id are attributed to this identity until you clock out,",
+            "store a kind:handoff memory, or close_task — whichever comes first.",
+          ].join("\n") + replaced,
+        }],
+      };
+    }
+
+    case "agent_clock_out": {
+      const existing = getActiveAgentSession(server);
+      if (!existing) {
+        // Idempotent by contract, so it is safe in a teardown path that cannot
+        // know whether anything was ever bound.
+        return {
+          content: [{ type: "text", text: "🕐 Already clocked out — no active session identity to clear." }],
+        };
+      }
+      clearAgentSession(server);
+      return {
+        content: [{
+          type: "text",
+          text: [
+            `🕐 Clocked out ${existing.agent_id} (bound ${existing.bound_at} via ${existing.source}).`,
+            "Calls that omit agent_id now fall back to the unassigned default.",
+          ].join("\n"),
+        }],
+      };
     }
 
     case "server_handshake": {

--- a/test/agent-clock-in-out.test.mjs
+++ b/test/agent-clock-in-out.test.mjs
@@ -1,0 +1,273 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import net from "node:net";
+import { spawn } from "node:child_process";
+
+// Issue #141. Auto-binding from clientInfo.name covers the common case, but an
+// agent cannot DECLARE an identity with it: the name is whatever the client
+// program calls itself, so several agents behind one client are
+// indistinguishable, and handing a session from one role to another mid-run
+// means reconnecting. These two tools are the explicit override.
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+async function waitForHealth(port, timeoutMs = 8000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      if (res.ok) return await res.json();
+    } catch { /* retry */ }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`daemon not healthy on ${port} within ${timeoutMs}ms`);
+}
+
+async function postMcp(port, body, sessionId) {
+  const headers = {
+    "content-type": "application/json",
+    accept: "application/json, text/event-stream",
+    "mcp-protocol-version": "2025-03-26",
+  };
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+  const res = await fetch(`http://127.0.0.1:${port}/mcp`, { method: "POST", headers, body: JSON.stringify(body) });
+  const text = await res.text();
+  return { status: res.status, sessionId: res.headers.get("mcp-session-id"), json: text ? JSON.parse(text) : undefined };
+}
+
+async function initSession(port, clientName) {
+  const res = await postMcp(port, {
+    jsonrpc: "2.0", id: 1, method: "initialize",
+    params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: clientName, version: "1.0.0" } },
+  });
+  return res.sessionId;
+}
+
+function toolCall(id, name, args) {
+  return { jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } };
+}
+
+const textOf = (res) => (res.json?.result?.content ?? []).map((c) => c?.text).filter(Boolean).join("\n");
+
+async function withDaemon(fn) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ndm-clock-test-"));
+  const daemonPort = await getFreePort();
+  const memoryFile = path.join(tempDir, "memories.json");
+  const daemon = spawn(process.execPath, [path.join(process.cwd(), "build", "index.js"), "--daemon"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      NEURODIVERGENT_MEMORY_MODE: "daemon",
+      NEURODIVERGENT_MEMORY_DAEMON_PORT: String(daemonPort),
+      NEURODIVERGENT_MEMORY_FILE: memoryFile,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let stderr = "";
+  daemon.stderr.on("data", (c) => { stderr += c.toString(); });
+  try {
+    await waitForHealth(daemonPort);
+    await fn(daemonPort, () => stderr, memoryFile);
+  } finally {
+    daemon.kill();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+// --- discoverability ------------------------------------------------------
+
+test("both tools are advertised, or an agent cannot find them", async () => {
+  // The whole point is an agent reaching for these deliberately. A tool the
+  // catalog does not list is a tool that does not exist, from the caller's side.
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "catalog-probe");
+    const listed = await postMcp(port, { jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }, session);
+    const names = (listed.json?.result?.tools ?? []).map((t) => t.name);
+    assert.ok(names.includes("agent_clock_in"), `agent_clock_in missing from tools/list: ${names.join(", ")}`);
+    assert.ok(names.includes("agent_clock_out"), `agent_clock_out missing from tools/list: ${names.join(", ")}`);
+
+    const mirrored = await postMcp(port, toolCall(3, "list_tools", {}), session);
+    const mirrorNames = JSON.parse(textOf(mirrored)).tools.map((t) => t.name);
+    assert.ok(mirrorNames.includes("agent_clock_in"), "agent_clock_in missing from the list_tools mirror");
+    assert.ok(mirrorNames.includes("agent_clock_out"), "agent_clock_out missing from the list_tools mirror");
+  });
+});
+
+// --- clock in -------------------------------------------------------------
+
+test("clocking in binds an identity that later writes inherit", async () => {
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "some-client");
+    await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "reviewer-agent" }), session);
+
+    const stored = await postMcp(port, toolCall(3, "store_memory", { content: "written while clocked in" }), session);
+    assert.match(textOf(stored), /reviewer-agent/, `write did not inherit the clocked-in identity:\n${textOf(stored)}`);
+  });
+});
+
+test("clocking in overrides the identity auto-bound from clientInfo.name", async () => {
+  // The case auto-binding cannot serve: several agents behind one client
+  // program, which reports a single clientInfo.name for all of them.
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "claude-code");
+    await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "risk-reviewer" }), session);
+
+    const stored = await postMcp(port, toolCall(3, "store_memory", { content: "second agent behind one client" }), session);
+    const text = textOf(stored);
+    assert.match(text, /risk-reviewer/, `override did not take:\n${text}`);
+    assert.doesNotMatch(text, /claude-code/, `the auto-bound identity survived the override:\n${text}`);
+  });
+});
+
+test("the handshake reports a clocked-in identity, and says it came from a clock-in", async () => {
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "some-client");
+    await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "architecture-reviewer" }), session);
+
+    const shook = textOf(await postMcp(port, toolCall(3, "server_handshake", {}), session));
+    assert.match(shook, /architecture-reviewer/, `handshake did not report the identity:\n${shook}`);
+    // Distinguishing a deliberate clock-in from an auto-bind is the point of
+    // having the tool at all — otherwise the handshake cannot tell a caller
+    // whether anyone actually declared this identity.
+    assert.match(shook, /clock_in/, `handshake did not attribute the bind to a clock-in:\n${shook}`);
+  });
+});
+
+test("clocking in accepts an explicit session_id", async () => {
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "some-client");
+    await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "a", session_id: "task-42" }), session);
+    const shook = textOf(await postMcp(port, toolCall(3, "server_handshake", {}), session));
+    assert.match(shook, /task-42/, `explicit session_id was ignored:\n${shook}`);
+  });
+});
+
+test("clocking in without an agent_id is refused", async () => {
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "some-client");
+    for (const args of [{}, { agent_id: "" }, { agent_id: "   " }, { agent_id: 7 }]) {
+      const res = await postMcp(port, toolCall(2, "agent_clock_in", args), session);
+      const isError = res.json?.result?.isError === true || Boolean(res.json?.error);
+      assert.ok(isError, `clock-in accepted ${JSON.stringify(args)}: ${JSON.stringify(res.json)}`);
+    }
+  });
+});
+
+// --- clock out ------------------------------------------------------------
+
+test("clocking out drops the identity, and later writes fall back to unassigned", async () => {
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "some-client");
+    await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "temp-agent" }), session);
+    await postMcp(port, toolCall(3, "agent_clock_out", {}), session);
+
+    const stored = await postMcp(port, toolCall(4, "store_memory", { content: "written after clocking out" }), session);
+    const text = textOf(stored);
+    assert.doesNotMatch(text, /temp-agent/, `the identity survived clock-out:\n${text}`);
+    assert.match(text, /unassigned/, `did not fall back to the unassigned default:\n${text}`);
+  });
+});
+
+test("clocking out twice is a stable no-op, not an error", async () => {
+  // An agent that cannot tell whether it is clocked in must be able to just
+  // call this. Idempotence is what makes it safe in a finally block.
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "some-client");
+    await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "temp-agent" }), session);
+    const first = await postMcp(port, toolCall(3, "agent_clock_out", {}), session);
+    const second = await postMcp(port, toolCall(4, "agent_clock_out", {}), session);
+
+    assert.notEqual(first.json?.result?.isError, true, `first clock-out errored:\n${textOf(first)}`);
+    assert.notEqual(second.json?.result?.isError, true, `second clock-out errored:\n${textOf(second)}`);
+    assert.match(textOf(second), /alread(y|ies)|no active|not clocked/i,
+      `a repeat clock-out should say plainly that nothing was bound:\n${textOf(second)}`);
+  });
+});
+
+test("clocking out with nothing bound is safe", async () => {
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "");
+    const res = await postMcp(port, toolCall(2, "agent_clock_out", {}), session);
+    // BOTH error channels: a thrown NMError surfaces as a JSON-RPC `error`,
+    // not as `result.isError`, so checking only the latter let a mutation that
+    // made this throw sail straight through.
+    assert.equal(res.json?.error, undefined, `errored on a cold clock-out:\n${JSON.stringify(res.json)}`);
+    assert.notEqual(res.json?.result?.isError, true, `errored on a cold clock-out:\n${textOf(res)}`);
+    assert.match(textOf(res), /alread(y|ies)|no active|not clocked/i,
+      `a cold clock-out should say plainly that nothing was bound:\n${textOf(res)}`);
+  });
+});
+
+// --- isolation ------------------------------------------------------------
+
+test("one session's clock-in cannot reach another session", async () => {
+  // The regression that matters most: identity lives in a WeakMap keyed by the
+  // per-session Server, and a process-global would silently cross-attribute
+  // every concurrent agent's writes.
+  await withDaemon(async (port) => {
+    const a = await initSession(port, "client-a");
+    const b = await initSession(port, "client-b");
+
+    await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "agent-one" }), a);
+    await postMcp(port, toolCall(3, "agent_clock_in", { agent_id: "agent-two" }), b);
+
+    const fromA = textOf(await postMcp(port, toolCall(4, "store_memory", { content: "from a" }), a));
+    const fromB = textOf(await postMcp(port, toolCall(5, "store_memory", { content: "from b" }), b));
+
+    assert.match(fromA, /agent-one/, `session A wrote as the wrong agent:\n${fromA}`);
+    assert.match(fromB, /agent-two/, `session B wrote as the wrong agent:\n${fromB}`);
+  });
+});
+
+test("clocking out of one session leaves the other clocked in", async () => {
+  await withDaemon(async (port) => {
+    const a = await initSession(port, "client-a");
+    const b = await initSession(port, "client-b");
+    await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "agent-one" }), a);
+    await postMcp(port, toolCall(3, "agent_clock_in", { agent_id: "agent-two" }), b);
+
+    await postMcp(port, toolCall(4, "agent_clock_out", {}), a);
+
+    const fromB = textOf(await postMcp(port, toolCall(5, "store_memory", { content: "b still working" }), b));
+    assert.match(fromB, /agent-two/, `clocking out of A also cleared B:\n${fromB}`);
+  });
+});
+
+// --- interaction with the existing auto-clock-out triggers ----------------
+
+test("a kind:handoff write still clears an identity that was clocked in explicitly", async () => {
+  // The existing triggers (#145/#146) must not become blind to identities that
+  // arrived through the new door — otherwise an explicit clock-in would leak
+  // past the end of the task it belonged to.
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "some-client");
+    await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "handoff-agent" }), session);
+
+    // Prove the clock-in took BEFORE testing that the handoff undoes it.
+    // Without this the test passes even when agent_clock_in does not exist:
+    // clientInfo.name auto-binds something, the handoff clears that instead,
+    // and every later assertion still reads exactly the same.
+    const before = textOf(await postMcp(port, toolCall(3, "store_memory", { content: "mid-task" }), session));
+    assert.match(before, /handoff-agent/, `clock-in never took, so this proves nothing:\n${before}`);
+
+    const handoff = await postMcp(port, toolCall(4, "store_memory", {
+      content: "HANDOFF: done for now", tags: ["kind:handoff"],
+    }), session);
+    assert.match(textOf(handoff), /cleared/i, `handoff did not clear an explicitly clocked-in identity:\n${textOf(handoff)}`);
+
+    const after = textOf(await postMcp(port, toolCall(5, "store_memory", { content: "after the handoff" }), session));
+    assert.doesNotMatch(after, /handoff-agent/, `identity survived the handoff:\n${after}`);
+  });
+});

--- a/test/agent-clock-in-out.test.mjs
+++ b/test/agent-clock-in-out.test.mjs
@@ -154,6 +154,40 @@ test("clocking in accepts an explicit session_id", async () => {
   });
 });
 
+// `store_memory` normalizes session_id FIRST (NFKC, trim, lower-case), rejects
+// what normalizes to empty, and validates the normalized value. Clock-in has to
+// match that flow exactly, or the same string is accepted by one tool and
+// refused by the other — and a session_id that means one thing on write means
+// another on the identity that produced the write.
+
+test("clocking in normalizes session_id the way store_memory does", async () => {
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "some-client");
+    // Validating BEFORE normalizing rejects this: the raw string fails the
+    // pattern on its leading space, though it trims to a perfectly good id.
+    const res = await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "a", session_id: "  Task-42  " }), session);
+    assert.equal(res.json?.error, undefined, `rejected a session_id that normalizes cleanly:\n${JSON.stringify(res.json)}`);
+    assert.notEqual(res.json?.result?.isError, true, `rejected a session_id that normalizes cleanly:\n${textOf(res)}`);
+
+    const shook = textOf(await postMcp(port, toolCall(3, "server_handshake", {}), session));
+    assert.match(shook, /session_id=task-42\b/, `session_id was not normalized to canonical form:\n${shook}`);
+  });
+});
+
+test("clocking in refuses a session_id that cannot normalize", async () => {
+  await withDaemon(async (port) => {
+    const session = await initSession(port, "some-client");
+    for (const bad of [null, "   ", " ", "not a valid id!", "-leading-dash"]) {
+      const res = await postMcp(port, toolCall(2, "agent_clock_in", { agent_id: "a", session_id: bad }), session);
+      const errored = Boolean(res.json?.error) || res.json?.result?.isError === true;
+      // Silently treating a bad session_id as "not provided" would bind the
+      // identity to a DIFFERENT session than the caller asked for, and say
+      // nothing — the caller's write then files under an id they never chose.
+      assert.ok(errored, `accepted session_id ${JSON.stringify(bad)}: ${JSON.stringify(res.json)}`);
+    }
+  });
+});
+
 test("clocking in without an agent_id is refused", async () => {
   await withDaemon(async (port) => {
     const session = await initSession(port, "some-client");


### PR DESCRIPTION
Closes #141 — the one task from the clock-in/out plan that was superseded rather than built.

## Why now

Identity has been bound automatically from the MCP handshake's `clientInfo.name` since per-connection sessions landed, and that covers the common case well: nothing to remember, nothing to forget. But it cannot serve two situations:

- **Several agents behind one MCP client** all report the same `clientInfo.name`, so their writes are indistinguishable. A sub-agent doing a risk review and one doing an architecture review are both `claude-code`.
- **Handing a session to a different role mid-run** previously meant reconnecting.

`server_handshake({agent_id})` already covered part of this as a side effect, but it isn't discoverable as a way to declare identity — it reads as a diagnostics call.

## What this adds

| Tool | Does |
|---|---|
| `agent_clock_in({agent_id, session_id?})` | Declares the identity this session writes as. Later calls that omit `agent_id` inherit it. |
| `agent_clock_out()` | Clears it; later calls fall back to the unassigned default. Idempotent. |

**Thin by design.** `bindAgentSession`, `clearAgentSession`, and `getActiveAgentSession` already exist and are already load-bearing — `server_handshake`'s override binds, `close_task` and `kind:handoff` clear. These tools are an explicit door onto machinery that was already exercised, not new architecture. The isolation guarantee therefore comes for free: identity lives in a `WeakMap` keyed by the per-session `Server`, so a clock-in in one session cannot reach another.

`source` gains `"clock_in"`, deliberately distinct from `"override"` — a caller reading the handshake needs to know whether an agent *declared* this identity or the server merely *inferred* it from the client program's name.

Auto-binding is unchanged. The existing auto-clock-out triggers clear an explicitly clocked-in identity exactly as they clear an inferred one, so an explicit identity cannot leak past the end of the task it belonged to.

## Testing

12 tests in `test/agent-clock-in-out.test.mjs`, driving a real daemon over real MCP sessions.

- **Discoverability** through both `tools/list` and the `list_tools` mirror — a tool the catalog does not list does not exist, from the caller's side.
- Bind and inherit; override of an auto-bound `clientInfo.name` identity; handshake attribution; explicit `session_id`.
- Four shapes of invalid `agent_id` (missing, empty, whitespace, non-string) are refused.
- Clock-out drops the identity and writes fall back to `unassigned`; idempotent twice over; safe from a cold start.
- **Cross-session isolation both ways** — two concurrent sessions keep separate identities, and clocking out of one leaves the other bound.
- A `kind:handoff` write still clears an explicitly clocked-in identity.

**Two guards proved by mutation**, and the second earned its keep. Making clock-out throw was *not* caught by "clocking out with nothing bound is safe", because a thrown `NMError` surfaces as a JSON-RPC `error` while the test only checked `result.isError`. Both channels are checked now, and the mutation fails both idempotence tests.

Similarly, the handoff test now asserts the clock-in **took** before testing that the handoff undoes it — without that it passed even with the tools entirely absent, since `clientInfo.name` auto-bound something and the handoff cleared that instead.

**Full suite: 407/409.** The 2 failures are the pre-existing template-wording drift in `test/agent-customization-wording.test.mjs`, untouched here. `npm run lint` clean.

## Note on the plan docs

`docs/superpowers/specs/2026-07-08-agent-clock-in-clock-out-design.md` and its plan describe a design that predates auto-binding. This PR implements the tools they name, but the surrounding model is different — identity is auto-bound by default and these are the explicit override, rather than clock-in being the only way in. The docs remain historical; the README and CHANGELOG describe what actually exists.
