### PR TITLE
fix(e2e): require the drum to have moved before calling a step settled

### DIFF
--- a/e2e/rolodex-layout.spec.ts
+++ b/e2e/rolodex-layout.spec.ts
@@ -1094,15 +1094,53 @@ test('stepping during a search lands on hits, the short way round', async ({ pag
   // not slack: Playwright's headless WebKit throttles requestAnimationFrame hard
   // enough that a single one-card step measured ~9 seconds to converge, against
   // well under one on desktop Chromium.
-  const settleDrum = async () => {
-    await page.evaluate(() => { (window as any).__lastDrumTransform = null; });
-    await page.waitForFunction(() => {
+  //
+  // Issue #173. The old detector called the drum settled on the first pair of
+  // identical samples, starting from a cold reset — so BOTH could be read
+  // before the drum had moved at all, leaving the front card reading as
+  // unchanged and collapsing `advances` to [0, ...].
+  //
+  // Measured on this engine (probe, 2026-08-03): the immediate read always
+  // still shows the pre-click transform, and the next distinct one lands at
+  // ~316ms — against a 300ms poll. A SIXTEEN MILLISECOND margin decided
+  // whether the old code settled prematurely, which is why it failed ~1 run in
+  // 3 on the reporting machine and 0 in 17 here. Nothing about the test
+  // changed between those; the machine did.
+  //
+  // Two conditions are needed to call a step finished, and the old code
+  // checked neither: the drum must have MOVED off its pre-click transform, and
+  // it must then have STOPPED. Stillness cannot be a fixed number of samples —
+  // the same step measured 8.4s here and 33.8s in the report, so on a slow
+  // machine two adjacent 300ms polls land inside one rAF frame mid-ease and
+  // look identical. The bar is therefore calibrated from the run itself: the
+  // drum is settled once it has held still for comfortably longer than the
+  // largest gap between changes observed during THIS step.
+  //
+  // Deliberately requires movement, so a step that never moves times out
+  // rather than passing. That is correct here — every step in this spec is
+  // asserted to advance — and a loud timeout beats silently reading the card
+  // being left instead of the one arrived at.
+  const drumTransform = () => page.evaluate(
+    () => (document.querySelector('#drum') as HTMLElement).style.transform);
+
+  const settleDrum = async (before: string) => {
+    await page.evaluate(() => { (window as any).__drumSettle = null; });
+    await page.waitForFunction((pre) => {
       const t = (document.querySelector('#drum') as HTMLElement).style.transform;
       const w = window as any;
-      if (w.__lastDrumTransform === t) return true;
-      w.__lastDrumTransform = t;
-      return false;
-    }, null, { timeout: 20_000, polling: 300 });
+      const now = Date.now();
+      if (!w.__drumSettle) w.__drumSettle = { last: t, lastChangeAt: now, maxGap: 0, moved: t !== pre };
+      const s = w.__drumSettle;
+      if (t !== s.last) {
+        s.maxGap = Math.max(s.maxGap, now - s.lastChangeAt);
+        s.last = t;
+        s.lastChangeAt = now;
+        if (t !== pre) s.moved = true;
+        return false;
+      }
+      if (!s.moved) return false;
+      return now - s.lastChangeAt > Math.max(1000, s.maxGap * 2.5);
+    }, before, { timeout: 45_000, polling: 300 });
   };
 
   let prev = await read();
@@ -1114,8 +1152,9 @@ test('stepping during a search lands on hits, the short way round', async ({ pag
   // and every extra step costs the WebKit run another ~9 seconds.
   const advances: number[] = [];
   for (let step = 1; step <= 2; step++) {
+    const beforeTransform = await drumTransform();
     await page.locator('#spinNext').click();
-    await settleDrum();
+    await settleDrum(beforeTransform);
     const now = await read();
 
     expect(now.hit, `step ${step} should land on a match, not simply the next card along`).toBe(true);


### PR DESCRIPTION
Closes #173.

## The bug

`settleDrum` called the drum settled on the **first pair of identical samples**, starting from a cold reset — so both could be read before the drum had moved at all. The front card then reads as unchanged, `advances` collapses to `[0, …]`, and `advances.some(d => d > 1)` trips.

## I could not reproduce the failure

**17 runs, 17 passes** — 9 via `--repeat-each`, then 8 isolated cold runs the way the issue measured. All ~22s, with none of the 5× duration spread the report saw (6.2s vs 33.8s).

That is not evidence the bug isn't there, so I measured the **mechanism** instead of chasing the assertion. A throwaway probe recorded every sample `settleDrum` sees:

```
=== step 1 ===
  samples taken: 28, distinct transforms: 25
  samples[0] still shows the pre-click transform: true
  first sample differing from pre-click: index 1 (316ms)
```

Both steps, every run: **the immediate first read always still shows the pre-click transform.** The cold-start window is real and always open. Whether the *second* sample catches motion is decided by a **~16ms margin** — the drum first moves at ~316ms, and the "300ms" poll actually lands at ~316ms once the evaluation round trip is counted.

Replaying the old and new rules over sample sequences pins it down:

| scenario | old rule | new rule |
|---|---|---|
| this machine (measured timings) | correct | correct |
| **first animation frame 24ms later** | **premature — reads the pre-click transform at 316ms** | correct |
| slow machine (~4× rAF, matching the 33.8s report) | **premature** | correct |

A 24ms shift flips it. That is why the rate is 1-in-3 on one machine and 0-in-17 on another: nothing about the test differs, the machine does. The model reproduces this machine's actual behaviour (old rule correct here, consistent with 17/17), which is what makes the other two rows credible.

## The fix

Two conditions, of which the old code checked neither: the drum must have **moved** off its pre-click transform, and it must then have **stopped**.

Stillness is deliberately **not** a fixed number of samples. The same step measured 8.4s here and 33.8s in the report, so rAF throttling varies ~4× between machines — and on a slow one, two adjacent 300ms polls land inside a single frame mid-ease and look identical. A fixed count would just move the false settle from the cold start into the middle of the ease. So the bar is calibrated from the run itself: **settled once the transform has held still for longer than 2.5× the largest gap between changes observed during this step**, floor 1s.

The helper now *requires* movement, so a step that never moves times out rather than passing. That is correct here — every step in this spec is asserted to advance — and a loud timeout beats silently reading the card being left instead of the one arrived at.

**On the timeout**, 20s → 45s: the issue asks not to fix this by widening timeouts, and this doesn't. The detector closes the window; the timeout merely has to not truncate a legitimately slow settle, which the report already measured at 33.8s. Left at 20s, the *fix* would time out on the machine the bug was reported from.

## Verification

- 6 isolated runs after the change: all pass, ~25s each (up from ~22s — the cost of confirming stillness).
- Full browser suite, both engines: **81 passed, 1 skipped** — exactly the pre-existing baseline.

## Honest limits

I never observed a red run, before or after, so I cannot claim a measured 1-in-3 → 0 improvement. What I can claim is measured: the cold-start window is always open on this engine, the old rule survives it by ~16ms, and the new rule does not depend on that margin at all. If it recurs on your machine, the probe that produced the numbers above is easy to reconstruct from the commit message.
